### PR TITLE
Improve image accessibility across static site

### DIFF
--- a/_wp_scripts/wpstyles.css
+++ b/_wp_scripts/wpstyles.css
@@ -1,5 +1,8 @@
 ﻿body {margin:0;padding:0;word-wrap:break-word;}
 img {border:none;}
+img.decorative {
+  /* Decorative images; no alternative text needed */
+}
 input {border:1px solid black;border-radius:2px;padding:0;}
 input[type=image] { border: none; }
 textarea {border:1px solid black;padding:0;}

--- a/about_us.html
+++ b/about_us.html
@@ -138,7 +138,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_5" style="position:absolute;left:40px;top:261px;width:938px;height:128px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">What is Foray Newfoundland and Labrador?</span></p>
@@ -150,14 +150,14 @@
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal"><span class="C-1"><br></span></p>
       </div>
-      <img alt="" src="_wp_generated/wpf1bb9412_06.png" id="txt_86" style="position:absolute;left:40px;top:420px;width:446px;height:2095px;">
-      <img alt="" src="_wp_generated/wpb423b1a6_06.png" id="txt_87" style="position:absolute;left:540px;top:420px;width:440px;height:2095px;">
+      <img alt="Article about Foray NL column 1" src="_wp_generated/wpf1bb9412_06.png" id="txt_86" style="position:absolute;left:40px;top:420px;width:446px;height:2095px;">
+      <img alt="Article about Foray NL column 2" src="_wp_generated/wpb423b1a6_06.png" id="txt_87" style="position:absolute;left:540px;top:420px;width:440px;height:2095px;">
       <div id="txt_164" style="position:absolute;left:42px;top:2541px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-3"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-4"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-4"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_88" style="position:absolute;left:42px;top:2540px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_88" style="position:absolute;left:42px;top:2540px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/articles_fungi_magazine.html
+++ b/articles_fungi_magazine.html
@@ -156,7 +156,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_23" style="position:absolute;left:41px;top:264px;width:938px;height:452px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Fungi Magazine</span></p>
@@ -185,7 +185,7 @@
         <p class="DefaultParagraph P-8"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-8"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_111" style="position:absolute;left:35px;top:764px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_111" style="position:absolute;left:35px;top:764px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/board.html
+++ b/board.html
@@ -138,7 +138,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
 
       <div class="OBJ-8" id="txt_8" style="position:absolute;left:41px;top:278px;width:348px;height:491px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -165,7 +165,7 @@
         <p class="DefaultParagraph P-5"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:42px;top:784px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:42px;top:784px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/bylaws.html
+++ b/bylaws.html
@@ -141,7 +141,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_9" style="position:absolute;left:45px;top:261px;width:933px;height:183px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-1">By Laws</span></p>
@@ -155,7 +155,7 @@
         <p class="DefaultParagraph P-4"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-4"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:478px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:478px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/consultants.html
+++ b/consultants.html
@@ -141,7 +141,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_10" style="position:absolute;left:26px;top:261px;width:953px;height:210px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">Consultants</span></p>
@@ -158,7 +158,7 @@
         <p class="DefaultParagraph P-7"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-7"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:41px;top:516px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:41px;top:516px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/contacts.html
+++ b/contacts.html
@@ -142,7 +142,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_219" style="position:absolute;left:518px;top:286px;width:349px;height:342px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">To comment on our website or to report missing links or errors, contact the webmaster via email:</span></p>
@@ -173,7 +173,7 @@
         <p class="DefaultParagraph P-8"><span class="C-5">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-8"><span class="C-5">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:40px;top:777px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:40px;top:777px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/current issue.html
+++ b/current issue.html
@@ -146,7 +146,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:17px;top:275px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -182,7 +182,7 @@
         <p class="DefaultParagraph P-6"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-6"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1379px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1379px;width:951px;height:3px;">
       <div id="txt_232" style="position:absolute;left:118px;top:1002px;width:873px;height:295px;overflow:hidden;">
         <p class="Normal2 P-7"><span class="C-4">Browse or Search Omphalina Indices Spreadsheet</span></p>
         <p class="Normal2 P-8"><span class="C-3"><br></span></p>
@@ -199,13 +199,13 @@
         <img alt="Omphalina_XIII_No2_2022-Sept (2).pdf" src="_wp_generated/wp0cba29c5_06.png" id="pic_229" style="position:absolute;left:304px;top:756px;width:155px;height:201px;">
       </a>
       <a href="https://drive.google.com/file/d/1BcVDfpfl5OsJOlYnHBXDI5N5UMMi5bzp/view" target="_blank">
-        <img alt="" src="_wp_generated/wpc337befe_06.png" id="pic_230" style="position:absolute;left:478px;top:756px;width:153px;height:201px;">
+        <img alt="Omphalina issue PDF" src="_wp_generated/wpc337befe_06.png" id="pic_230" style="position:absolute;left:478px;top:756px;width:153px;height:201px;">
       </a>
       <a href="Omphalina_XIV_No2.pdf" target="_blank">
         <img alt="Omphalina_XIV_No2.pdf" src="_wp_generated/wp8d1a7684_06.png" id="pic_239" style="position:absolute;left:648px;top:757px;width:156px;height:200px;">
       </a>
       <a href="https://drive.google.com/file/d/16zo92TFDbQP90_7fJKELq_X6ZDAJiNbJ/view" target="_blank">
-        <img alt="" src="_wp_generated/wpcecd6281_06.png" id="pic_238" style="position:absolute;left:634px;top:325px;width:267px;height:347px;">
+        <img alt="Omphalina issue PDF" src="_wp_generated/wpcecd6281_06.png" id="pic_238" style="position:absolute;left:634px;top:325px;width:267px;height:347px;">
       </a>
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">

--- a/facebook_links.html
+++ b/facebook_links.html
@@ -133,32 +133,32 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_162" style="position:absolute;left:247px;top:274px;width:718px;height:937px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
       </div>
-      <img alt="" src="_wp_generated/wp3baf4122_06.png" id="pic_34" style="position:absolute;left:33px;top:274px;width:193px;height:239px;">
+      <img alt="Facebook logo collage" src="_wp_generated/wp3baf4122_06.png" id="pic_34" style="position:absolute;left:33px;top:274px;width:193px;height:239px;">
       <a href="https://www.facebook.com/groups/214397418588682/" target="_blank">
-        <img alt="" src="_wp_generated/wp0df8b6ea_06.png" id="pic_105" style="position:absolute;left:259px;top:478px;width:694px;height:170px;">
+        <img alt="Foray NL Facebook group banner" src="_wp_generated/wp0df8b6ea_06.png" id="pic_105" style="position:absolute;left:259px;top:478px;width:694px;height:170px;">
       </a>
       <a href="https://www.facebook.com/groups/MushroomID/" target="_blank">
-        <img alt="" src="_wp_generated/wpaf16b2f9_06.png" id="pic_106" style="position:absolute;left:259px;top:1028px;width:695px;height:169px;">
+        <img alt="Mushroom ID Facebook group banner" src="_wp_generated/wpaf16b2f9_06.png" id="pic_106" style="position:absolute;left:259px;top:1028px;width:695px;height:169px;">
       </a>
       <a href="https://www.facebook.com/groups/mycologicalwordoftheday/" target="_blank">
-        <img alt="" src="_wp_generated/wp9da82829_06.png" id="pic_107" style="position:absolute;left:259px;top:663px;width:694px;height:169px;">
+        <img alt="Mycological Word of the Day Facebook group banner" src="_wp_generated/wp9da82829_06.png" id="pic_107" style="position:absolute;left:259px;top:663px;width:694px;height:169px;">
       </a>
       <a href="https://www.facebook.com/groups/1626105040960720/" target="_blank">
-        <img alt="" src="_wp_generated/wp67ce6701_06.png" id="pic_108" style="position:absolute;left:259px;top:285px;width:694px;height:169px;">
+        <img alt="Facebook group banner" src="_wp_generated/wp67ce6701_06.png" id="pic_108" style="position:absolute;left:259px;top:285px;width:694px;height:169px;">
       </a>
       <a href="https://www.facebook.com/groups/43995545858/" target="_blank">
-        <img alt="" src="_wp_generated/wpaa9fb8d5_06.png" id="pic_109" style="position:absolute;left:259px;top:846px;width:695px;height:170px;">
+        <img alt="Facebook group banner" src="_wp_generated/wpaa9fb8d5_06.png" id="pic_109" style="position:absolute;left:259px;top:846px;width:695px;height:170px;">
       </a>
       <div id="txt_164" style="position:absolute;left:36px;top:1254px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-2"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_93" style="position:absolute;left:36px;top:1252px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_93" style="position:absolute;left:36px;top:1252px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/flickr_image_index.html
+++ b/flickr_image_index.html
@@ -162,7 +162,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_111" style="position:absolute;left:32px;top:416px;width:344px;height:813px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal2 P-2"><span class="C-2">Phylum: BASIDIOMYCOTINA</span></p>
@@ -232,9 +232,9 @@
         <p class="DefaultParagraph P-14"><a href="https://www.flickr.com/photos/foray_nl/collections/72157633088249116/" target="_blank" class="C-3">SLIME MOLDS</a></p>
         <p class="DefaultParagraph"><span class="C-8"><br></span></p>
       </div>
-      <img alt="" src="_wp_generated/wp80879bb4_06.png" id="pic_39" style="position:absolute;left:388px;top:417px;width:236px;height:173px;">
-      <img alt="" src="_wp_generated/wpd0c3bd13_06.png" id="pic_40" style="position:absolute;left:388px;top:622px;width:236px;height:177px;">
-      <img alt="" src="_wp_generated/wpdd94e1ed_06.png" id="pic_41" style="position:absolute;left:389px;top:831px;width:236px;height:175px;">
+      <img alt="Mushroom photograph" src="_wp_generated/wp80879bb4_06.png" id="pic_39" style="position:absolute;left:388px;top:417px;width:236px;height:173px;">
+      <img alt="Mushroom photograph" src="_wp_generated/wpd0c3bd13_06.png" id="pic_40" style="position:absolute;left:388px;top:622px;width:236px;height:177px;">
+      <img alt="Mushroom photograph" src="_wp_generated/wpdd94e1ed_06.png" id="pic_41" style="position:absolute;left:389px;top:831px;width:236px;height:175px;">
       <div class="OBJ-9" id="txt_113" style="position:absolute;left:29px;top:279px;width:964px;height:124px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-9"><br></span></p>
         <p class="DefaultParagraph P-19"><span class="C-1">Foray Newfoundland and Labrador Fungi Images Collection on Flickr</span></p>
@@ -246,7 +246,7 @@
         <p class="DefaultParagraph P-22"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-22"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_98" style="position:absolute;left:36px;top:1275px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_98" style="position:absolute;left:36px;top:1275px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/flickr_voucher_images.html
+++ b/flickr_voucher_images.html
@@ -136,39 +136,39 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_165" style="position:absolute;left:37px;top:278px;width:956px;height:243px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">Phyla</span></p>
       </div>
       <a href="https://www.flickr.com/photos/foray_nl/collections/72157648553774953/" target="_blank">
-        <img alt="" src="_wp_generated/wp45fffe59_06.png" id="pic_112" style="position:absolute;left:54px;top:348px;width:161px;height:150px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wp45fffe59_06.png" id="pic_112" style="position:absolute;left:54px;top:348px;width:161px;height:150px;">
       </a>
       <a href="https://www.flickr.com/photos/foray_nl/collections/72157629338679387/" target="_blank">
-        <img alt="" src="_wp_generated/wp36323536_06.png" id="pic_113" style="position:absolute;left:247px;top:348px;width:158px;height:150px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wp36323536_06.png" id="pic_113" style="position:absolute;left:247px;top:348px;width:158px;height:150px;">
       </a>
       <a href="https://www.flickr.com/photos/foray_nl/collections/72157629338420891/" target="_blank">
-        <img alt="" src="_wp_generated/wpefe06a8b_06.png" id="pic_114" style="position:absolute;left:429px;top:348px;width:156px;height:150px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wpefe06a8b_06.png" id="pic_114" style="position:absolute;left:429px;top:348px;width:156px;height:150px;">
       </a>
       <a href="https://www.flickr.com/photos/foray_nl/collections/72157632522930364/" target="_blank">
-        <img alt="" src="_wp_generated/wp50350806_06.png" id="pic_115" style="position:absolute;left:617px;top:348px;width:160px;height:151px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wp50350806_06.png" id="pic_115" style="position:absolute;left:617px;top:348px;width:160px;height:151px;">
       </a>
       <a href="https://www.flickr.com/photos/foray_nl/collections/72157633088249116/" target="_blank">
-        <img alt="" src="_wp_generated/wpe13d64a8_06.png" id="pic_116" style="position:absolute;left:815px;top:348px;width:158px;height:150px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wpe13d64a8_06.png" id="pic_116" style="position:absolute;left:815px;top:348px;width:158px;height:150px;">
       </a>
       <div class="OBJ-8" id="txt_166" style="position:absolute;left:37px;top:530px;width:956px;height:296px;overflow:hidden;">
         <p class="DefaultParagraph P-2"><span class="C-1"><br></span></p>
         <p class="Normal P-3"><span class="C-2">Genera</span></p>
       </div>
       <a href="https://www.flickr.com/photos/foray_nl/sets" target="_blank">
-        <img alt="" src="_wp_generated/wpa55102c2_06.png" id="pic_117" style="position:absolute;left:47px;top:595px;width:936px;height:217px;">
+        <img alt="Mushroom voucher image" src="_wp_generated/wpa55102c2_06.png" id="pic_117" style="position:absolute;left:47px;top:595px;width:936px;height:217px;">
       </a>
       <div id="txt_164" style="position:absolute;left:37px;top:872px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-3"><br></span></p>
         <p class="DefaultParagraph P-5"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_109" style="position:absolute;left:37px;top:871px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_109" style="position:absolute;left:37px;top:871px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/foray_2023.html
+++ b/foray_2023.html
@@ -144,13 +144,13 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div id="txt_164" style="position:absolute;left:44px;top:872px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-2"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_95" style="position:absolute;left:44px;top:871px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_95" style="position:absolute;left:44px;top:871px;width:951px;height:3px;">
       <div id="txt_237" style="position:absolute;left:459px;top:272px;width:473px;height:575px;overflow:hidden;">
         <p class="Normal2 P-3"><span class="C-3"><br></span></p>
         <p class="Normal2 P-4"><span class="C-4">Foray 2023</span></p>
@@ -175,7 +175,7 @@
         <p class="Normal P-9"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
         <p class="Normal"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
       </div>
-      <img alt="" src="_wp_generated/wp81bc60e1_05_06.jpg" id="pic_232" style="position:absolute;left:20px;top:271px;width:418px;height:540px;">
+      <img alt="Foray 2023 event poster" src="_wp_generated/wp81bc60e1_05_06.jpg" id="pic_232" style="position:absolute;left:20px;top:271px;width:418px;height:540px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/foray_2024.html
+++ b/foray_2024.html
@@ -178,7 +178,7 @@
         <p class="DefaultParagraph P-2"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_95" style="position:absolute;left:44px;top:871px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_95" style="position:absolute;left:44px;top:871px;width:951px;height:3px;">
       <div id="txt_237" style="position:absolute;left:459px;top:272px;width:473px;height:575px;overflow:hidden;">
         <p class="Normal2 P-3"><span class="C-3"><br></span></p>
         <p class="Normal2 P-4"><span class="C-4">Foray 2024</span></p>

--- a/foray_reports.html
+++ b/foray_reports.html
@@ -148,7 +148,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_13" style="position:absolute;left:247px;top:280px;width:733px;height:282px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Foray Reports</span></p>
@@ -159,13 +159,13 @@
         <p class="Normal P-6">Our reports also list our partners. Without their support this work would not have happened.</p>
         <p class="Normal P-7"><a class="C-4"><br></a></p>
       </div>
-      <img alt="" src="_wp_generated/wp3ae06e99_05_06.jpg" id="pic_37" style="position:absolute;left:40px;top:280px;width:180px;height:234px;">
+      <img alt="Foray report cover" src="_wp_generated/wp3ae06e99_05_06.jpg" id="pic_37" style="position:absolute;left:40px;top:280px;width:180px;height:234px;">
       <div id="txt_164" style="position:absolute;left:36px;top:600px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-8"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-9"><span class="C-5">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-9"><span class="C-5">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_89" style="position:absolute;left:36px;top:599px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_89" style="position:absolute;left:36px;top:599px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/foray_reports_all.html
+++ b/foray_reports_all.html
@@ -149,7 +149,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:32px;top:705px;width:948px;height:3436px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
@@ -297,7 +297,7 @@
         <p class="DefaultParagraph P-9"><span class="C-9">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-9"><span class="C-9">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:42px;top:4728px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:42px;top:4728px;width:951px;height:3px;">
       <a href="omphaline/Foray%20Report%202019%20and%20eForay%202020.pdf" target="_blank">
         <img alt="Foray Report 2019 and eForay 2020.pdf" src="_wp_generated/wp345de84d_06.png" id="pic_237" style="position:absolute;left:48px;top:1958px;width:205px;height:263px;">
       </a>

--- a/fungal_websites.html
+++ b/fungal_websites.html
@@ -148,7 +148,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_182" style="position:absolute;left:32px;top:278px;width:969px;height:1077px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">The websites listed below contain resources about fungi. There are many resources available on the web, so these are the one4s selected/suggested that can be used to further your knowledge about both mushrooms and lichens.</span></p>

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         <p class="DefaultParagraph P-3"><span class="C-3">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-3">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp993d91bd_06.png" id="img_87" style="position:absolute;left:24px;top:1300px;width:975px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp993d91bd_06.png" id="img_87" style="position:absolute;left:24px;top:1300px;width:975px;height:3px;">
       <div class="OBJ-1" id="txt_22" style="position:absolute;left:23px;top:830px;width:674px;height:453px;overflow:hidden;">
         <p class="Normal P-4"><span class="C-2"><br></span></p>
         <p class="Normal P-5"><span class="C-4">Voitk, A: &nbsp;&nbsp;A Little Illustrated Book of Common Mushrooms of Newfoundland and Labrador. ISBN 978-<wbr>0-<wbr>9699509-<wbr>4-<wbr>3</span></p>
@@ -188,7 +188,7 @@
       <div class="OBJ-1" id="txt_116" style="position:absolute;left:724px;top:302px;width:281px;height:761px;overflow:hidden;">
         <p class="DefaultParagraph P-13"><span class="C-4"><br></span></p>
         <p class="DefaultParagraph P-14"><span class="C-3"><br></span></p>
-        <p class="DefaultParagraph P-14"><span class="C-3"><img alt="" src="_wp_generated/wp11143d05_05_06.jpg" id="pic_234" style="float:left;margin:6px;width:248px;height:358px;"></span><span class="C-4">Size: <span class="C-6">22 x 32 in, / 56 x 81 cm</span></span></p>
+        <p class="DefaultParagraph P-14"><span class="C-3"><img alt="Mushroom poster available for sale" src="_wp_generated/wp11143d05_05_06.jpg" id="pic_234" style="float:left;margin:6px;width:248px;height:358px;"></span><span class="C-4">Size: <span class="C-6">22 x 32 in, / 56 x 81 cm</span></span></p>
         <p class="Normal P-15"><span class="C-4"><br></span></p>
         <p class="DefaultParagraph P-15"><span class="C-4">Available from</span></p>
         <p class="DefaultParagraph P-16"><span class="C-6">Gros Morne Co-<wbr>operating Association stores at the Visitor Reception Centre</span></p>
@@ -204,9 +204,9 @@
         <p class="DefaultParagraph P-2"><span class="C-2">Click on the Foray 2025 tab for more information.</span></p>
       </div>
       <img alt="Foray 2025 Poster" src="images/Foray-2025-Poster.png" id="pic_231" style="position:absolute;left:366px;top:304px;width:326px;height:421px;">
-      <img alt="" src="_wp_generated/wpb8d4985e_05_06.jpg" id="pic_233" style="position:absolute;left:84px;top:323px;width:202px;height:241px;">
-      <img alt="" src="_wp_generated/wp7cfacecc_05_06.jpg" id="pic_235" style="position:absolute;left:423px;top:886px;width:177px;height:283px;">
-      <img alt="" src="_wp_generated/wp302e9c15_05_06.jpg" id="pic_236" style="position:absolute;left:723px;top:1094px;width:267px;height:178px;">
+      <img alt="" class="decorative" src="_wp_generated/wpb8d4985e_05_06.jpg" id="pic_233" style="position:absolute;left:84px;top:323px;width:202px;height:241px;">
+      <img alt="" class="decorative" src="_wp_generated/wp7cfacecc_05_06.jpg" id="pic_235" style="position:absolute;left:423px;top:886px;width:177px;height:283px;">
+      <img alt="" class="decorative" src="_wp_generated/wp302e9c15_05_06.jpg" id="pic_236" style="position:absolute;left:723px;top:1094px;width:267px;height:178px;">
       <div id="nav_4" class="OBJ-3" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
         <a href="index.html" id="nav_4_B1" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
           <span>Home</span>
@@ -236,7 +236,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/membership.html
+++ b/membership.html
@@ -158,7 +158,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_51" style="position:absolute;left:42px;top:282px;width:920px;height:701px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Membership</span></p>
@@ -190,7 +190,7 @@
         <p class="DefaultParagraph P-15"><span class="C-9">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-15"><span class="C-9">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_100" style="position:absolute;left:36px;top:1066px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_100" style="position:absolute;left:36px;top:1066px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/mission.html
+++ b/mission.html
@@ -147,7 +147,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_5" style="position:absolute;left:38px;top:259px;width:947px;height:81px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">Foray Newfoundland and Labrador is a not-<wbr>for-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada.</span></p>
@@ -180,7 +180,7 @@
         <p class="DefaultParagraph P-12"><span class="C-3">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-12"><span class="C-3">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:877px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:877px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/mycophyle_articles.html
+++ b/mycophyle_articles.html
@@ -164,7 +164,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_163" style="position:absolute;left:45px;top:271px;width:935px;height:378px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><a href="articles/2cups.pdf" class="C-2"><br></a></p>
@@ -184,13 +184,13 @@
         <p class="DefaultParagraph P-3"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-4"><span class="C-8"><br></span></p>
       </div>
-      <img alt="" src="_wp_generated/wp05e9f8ff_06.png" id="pic_131" style="position:absolute;left:60px;top:287px;width:599px;height:118px;">
+      <img alt="Mycophile articles header" src="_wp_generated/wp05e9f8ff_06.png" id="pic_131" style="position:absolute;left:60px;top:287px;width:599px;height:118px;">
       <div id="txt_164" style="position:absolute;left:36px;top:719px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-5"><span class="C-8"><br></span></p>
         <p class="DefaultParagraph P-6"><span class="C-9">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-6"><span class="C-9">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_113" style="position:absolute;left:36px;top:717px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_113" style="position:absolute;left:36px;top:717px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina.html
+++ b/omphalina.html
@@ -139,7 +139,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_48" style="position:absolute;left:300px;top:280px;width:685px;height:399px;overflow:hidden;">
         <p class="Normal P-1"><br></p>
         <p class="Normal P-2">Omphalina: The Newsletter of Foray Newfoundland and Labrador</p>
@@ -156,7 +156,7 @@
         <p class="DefaultParagraph P-7"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-7"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:35px;top:789px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:35px;top:789px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2010_1.html
+++ b/omphalina_2010_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -193,7 +193,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_107" style="position:absolute;left:36px;top:1091px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_107" style="position:absolute;left:36px;top:1091px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2011_1.html
+++ b/omphalina_2011_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -209,7 +209,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_108" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_108" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2012_1.html
+++ b/omphalina_2012_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -227,7 +227,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_105" style="position:absolute;left:36px;top:1399px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_105" style="position:absolute;left:36px;top:1399px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2013_1.html
+++ b/omphalina_2013_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -221,7 +221,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_106" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_106" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2014.html
+++ b/omphalina_2014.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -221,7 +221,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_104" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_104" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2015_1.html
+++ b/omphalina_2015_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -193,7 +193,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_102" style="position:absolute;left:36px;top:1098px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_102" style="position:absolute;left:36px;top:1098px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/omphalina_2017_1.html
+++ b/omphalina_2017_1.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -172,7 +172,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_103" style="position:absolute;left:36px;top:1081px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_103" style="position:absolute;left:36px;top:1081px;width:951px;height:3px;">
       <a href="omphaline/O-VIII-1.pdf">
         <img alt="O-VIII-1.pdf" src="_wp_generated/wpf1eec3af_06.png" id="pic_121" style="position:absolute;left:79px;top:328px;width:180px;height:237px;">
       </a>

--- a/omphaline/page40.html
+++ b/omphaline/page40.html
@@ -144,7 +144,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:22px;top:277px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -172,7 +172,7 @@
         <p class="DefaultParagraph P-5"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1549px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1549px;width:951px;height:3px;">
       <div id="txt_224" style="position:absolute;left:477px;top:592px;width:190px;height:31px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-1">Vol 12 Issue 3</span></p>
       </div>

--- a/osprey.html
+++ b/osprey.html
@@ -157,7 +157,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_163" style="position:absolute;left:46px;top:266px;width:944px;height:761px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-2"><span class="C-2">Nature Newfoundland and Labrador; Osprey Magazine</span></p>
@@ -200,7 +200,7 @@
         <p class="DefaultParagraph P-7"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-7"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_112" style="position:absolute;left:36px;top:1076px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_112" style="position:absolute;left:36px;top:1076px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/page36.html
+++ b/page36.html
@@ -137,7 +137,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph"><span class="C-2"><br></span></p>
@@ -199,7 +199,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_103" style="position:absolute;left:36px;top:1081px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_103" style="position:absolute;left:36px;top:1081px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/page37.html
+++ b/page37.html
@@ -140,7 +140,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:1159px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -161,7 +161,7 @@
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-2"><span class="C-3"><img alt="" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span></p>
+        <p class="Normal P-2"><span class="C-3"><img alt="" class="decorative" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span></p>
       </div>
       <div id="txt_168" style="position:absolute;left:67px;top:578px;width:180px;height:32px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-4">Vol 9, No 1</span></p>
@@ -183,7 +183,7 @@
         <p class="DefaultParagraph P-6"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-6"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1483px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1483px;width:951px;height:3px;">
       <div id="txt_183" style="position:absolute;left:306px;top:944px;width:180px;height:32px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-4">Vol 9, No 6</span></p>
       </div>

--- a/page38.html
+++ b/page38.html
@@ -142,7 +142,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:454px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -174,7 +174,7 @@
         <p class="DefaultParagraph P-5"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wpab575c69_06.png" id="img_94" style="position:absolute;left:30px;top:738px;width:978px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wpab575c69_06.png" id="img_94" style="position:absolute;left:30px;top:738px;width:978px;height:3px;">
       <a href="omphaline/Omphalina-XI-1.pdf" target="_blank">
         <img alt="Omphalina-XI-1.pdf" src="_wp_generated/wp2af141bf_06.png" id="pic_203" style="position:absolute;left:51px;top:343px;width:190px;height:246px;">
       </a>
@@ -185,7 +185,7 @@
         <p class="DefaultParagraph P-4"><span class="C-1">Vol XL Issue 1</span></p>
       </div>
       <div id="txt_225" style="position:absolute;left:259px;top:612px;width:198px;height:31px;overflow:hidden;">
-        <p class="DefaultParagraph P-6"><span class="C-6"><img alt="" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span><span class="C-1">Vol XL Issue 2</span></p>
+        <p class="DefaultParagraph P-6"><span class="C-6"><img alt="" class="decorative" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span><span class="C-1">Vol XL Issue 2</span></p>
         <p class="DefaultParagraph P-4"><span class="C-1"><br></span></p>
       </div>
       <a href="omphaline/Omphalina_XI-3.pdf" target="_blank">

--- a/page39.html
+++ b/page39.html
@@ -139,7 +139,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:425px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -160,14 +160,14 @@
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-3"><span class="C-4"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-2"><span class="C-3"><img alt="" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span></p>
+        <p class="Normal P-2"><span class="C-3"><img alt="" class="decorative" src="_wp_generated/wp50252a1a_06.png" id="pic_126" style="float:left;margin:6px;width:0px;height:0px;"></span></p>
       </div>
       <div id="txt_164" style="position:absolute;left:42px;top:719px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-5"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:42px;top:717px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:42px;top:717px;width:951px;height:3px;">
       <a href="omphaline/Omphalina-X-1.pdf" target="_blank">
         <img alt="Omphalina-X-1.pdf" src="_wp_generated/wp1346f5a4_06.png" id="pic_197" style="position:absolute;left:48px;top:314px;width:191px;height:241px;">
       </a>

--- a/page40.html
+++ b/page40.html
@@ -144,7 +144,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:22px;top:277px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -172,7 +172,7 @@
         <p class="DefaultParagraph P-5"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1549px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:36px;top:1549px;width:951px;height:3px;">
       <div id="txt_224" style="position:absolute;left:477px;top:592px;width:190px;height:31px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-1">Vol 12 Issue 3</span></p>
       </div>

--- a/resources.html
+++ b/resources.html
@@ -145,7 +145,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_174" style="position:absolute;left:32px;top:278px;width:958px;height:1149px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Links:</span></p>
@@ -180,7 +180,7 @@
         <p class="DefaultParagraph P-9"><span class="C-7">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-9"><span class="C-7">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_92" style="position:absolute;left:36px;top:1484px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_92" style="position:absolute;left:36px;top:1484px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/science.html
+++ b/science.html
@@ -175,7 +175,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_221" style="position:absolute;left:31px;top:298px;width:955px;height:2458px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-1"><span class="C-1">One of the pleasures of a Foray is meeting like-<wbr>minded people to share in the collection, identification and cataloguing of the mycota of Newfoundland Labrador. This pleasurable task sometimes leads to academic research on fungi using on our collection stored in the herbarium at the Grenfell Campus of Memorial University. Some of this research also involves members of Foray NL. This work enables Foray NL to attract national and international academics to be part of our annual Foray &nbsp;and to collaborate in investigative projects that often result in scholarly articles like the ones listed below. </span></p>

--- a/search.html
+++ b/search.html
@@ -152,7 +152,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:762px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
@@ -194,7 +194,7 @@
         <p class="DefaultParagraph P-12"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-12"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:45px;top:1073px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:45px;top:1073px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/species_list_by_foray.html
+++ b/species_list_by_foray.html
@@ -139,7 +139,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:182px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-1"><span class="C-2">Below are links to PDF files that contain lists of species collected at various Forays since Foray Newfoundland and Labrador started in 2003. In recent years, the lists were included in Foray Reports. These are been extracted from the reports and and included here as separate documents. More recent species lists also include lichens.</span></p>
@@ -156,7 +156,7 @@
         <p class="DefaultParagraph P-3"><span class="C-4">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp94041f0a_06.png" id="img_103" style="position:absolute;left:45px;top:2628px;width:948px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp94041f0a_06.png" id="img_103" style="position:absolute;left:45px;top:2628px;width:948px;height:3px;">
       <div id="txt_185" style="position:absolute;left:288px;top:773px;width:213px;height:45px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-5">Gros Morne National Park</span></p>
         <p class="Normal P-4"><span class="C-5">2003</span></p>

--- a/species_list_explanations.html
+++ b/species_list_explanations.html
@@ -149,7 +149,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_11" style="position:absolute;left:37px;top:272px;width:942px;height:887px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal2 P-2">The exact number of mushroom species growing in the province of Newfoundland and Labrador is unknown. Estimates have been placed at around 8000, somewhat short of the ten thousand believed to be growing on adjacent continental North America. Foray NL believes that species considered typical in this province are around 1200 -<wbr> 1500 and that most have been located. It is likely that with time and increased canvassing of the province, more species will be discovered. </p>
@@ -173,7 +173,7 @@
         <p class="DefaultParagraph P-7"><span class="C-8">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-7"><span class="C-8">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_90" style="position:absolute;left:36px;top:1183px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_90" style="position:absolute;left:36px;top:1183px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/species_lists.html
+++ b/species_lists.html
@@ -164,7 +164,7 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_11" style="position:absolute;left:28px;top:273px;width:551px;height:515px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><br></p>
@@ -189,7 +189,7 @@
         <p class="DefaultParagraph P-14"><span class="C-8">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-14"><span class="C-8">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_101" style="position:absolute;left:36px;top:871px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_101" style="position:absolute;left:36px;top:871px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>

--- a/submission_guidelines.html
+++ b/submission_guidelines.html
@@ -131,16 +131,16 @@
           <span>Membership</span>
         </a>
       </div>
-      <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
+      <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <map id="map1" name="map1"><area shape="rect" coords="128,158,289,178" href="omphaline/App1.pdf" target="_blank" alt=""></map>
-      <img alt="" usemap="#map1" src="_wp_generated/wpce7caff1_06.png" id="txt_109" style="position:absolute;left:259px;top:283px;width:700px;height:263px;">
-      <img alt="" src="_wp_generated/wpf9fd1c34_06.png" id="pic_46" style="position:absolute;left:43px;top:282px;width:204px;height:264px;">
+      <img alt="Submission guidelines diagram" usemap="#map1" src="_wp_generated/wpce7caff1_06.png" id="txt_109" style="position:absolute;left:259px;top:283px;width:700px;height:263px;">
+      <img alt="Submission guidelines illustration" src="_wp_generated/wpf9fd1c34_06.png" id="pic_46" style="position:absolute;left:43px;top:282px;width:204px;height:264px;">
       <div id="txt_164" style="position:absolute;left:36px;top:683px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-2"><span class="C-2">For Questions or Comments contact the webmaster.</span></p>
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
-      <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_96" style="position:absolute;left:36px;top:681px;width:951px;height:3px;">
+      <img alt="" class="decorative" src="_wp_generated/wp293ec477_06.png" id="img_96" style="position:absolute;left:36px;top:681px;width:951px;height:3px;">
       <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
         <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
           <span>2003-Present</span>


### PR DESCRIPTION
## Summary
- add `.decorative` CSS class and apply to purely decorative images
- provide descriptive `alt` text for key images across the site
- ensure header banner includes meaningful `alt` text on every page

## Testing
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_689a4ea4649c832198874f1a739842b5