### PR TITLE
Add shared stylesheet for navigation background

### DIFF
--- a/about_us.html
+++ b/about_us.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="Foray Newfoundland and Labrador">
     <meta name="description" content="Presents a short history of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/articles_fungi_magazine.html
+++ b/articles_fungi_magazine.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Lists articles written by Foray Newfoundland and Labrador members and published in Fungi Magazine.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,3 @@
+#nav_4 {
+  background: transparent url('/_wp_generated/wpb765fade_06.png') no-repeat 34px 0px;
+}

--- a/board.html
+++ b/board.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="List of Board members for Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/bylaws.html
+++ b/bylaws.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Links to pdf files containing the bylaws of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/consultants.html
+++ b/consultants.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Legal and Financial consultants for Foary Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/contacts.html
+++ b/contacts.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Fill-in form to contact Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/current issue.html
+++ b/current issue.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="Current Issue of Omphaliina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/facebook_links.html
+++ b/facebook_links.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Lists Facebook Groups related to mycology.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/flickr_image_index.html
+++ b/flickr_image_index.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="Flickr, mushrooms, newfoundland and labrador, foray Newfoundland and Labrador">
     <meta name="description" content="Displays lists of mushrooms groups with voucher images stored on Flockr.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/flickr_voucher_images.html
+++ b/flickr_voucher_images.html
@@ -15,8 +15,8 @@
     <meta name="generator" content="Serif WebPlus X7">
     <meta name="viewport" content="width=1014">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/foray_2023.html
+++ b/foray_2023.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, foray, newfoundland and labrador">
     <meta name="description" content="Foray Newfoundland and Labrador 2020">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/foray_2024.html
+++ b/foray_2024.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, foray, newfoundland and labrador">
     <meta name="description" content="Foray Newfoundland and Labrador 2020">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/foray_reports.html
+++ b/foray_reports.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms. foray, newfoundland, labrador, fungi, foray reports">
     <meta name="description" content="Foray Reports 2003 to present.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/foray_reports_all.html
+++ b/foray_reports_all.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology, foray reports">
     <meta name="description" content="Foray reports, 2003-present for  Foray Newfoundland and Labrador">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/fungal_websites.html
+++ b/fungal_websites.html
@@ -15,8 +15,8 @@
     <meta name="generator" content="Serif WebPlus X7">
     <meta name="viewport" content="width=1024">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@
     <meta name="robots" content="index,follow">
 
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .P-1 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .C-1 { line-height:20.00px;font-family:"Times New Roman", serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-2 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
@@ -59,7 +60,6 @@
       .C-12 { line-height:20.00px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-20 { margin-left:10.5px;text-indent:-0.5px;line-height:22.7px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .C-13 { font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
-      .OBJ-3 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
       .OBJ-4,.OBJ-4:link,.OBJ-4:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-4:hover { background-position:0px -78px; }
       .OBJ-4:active,a:link.OBJ-4.Activated,a:link.OBJ-4.Down,a:visited.OBJ-4.Activated,a:visited.OBJ-4.Down,.OBJ-4.Activated,.OBJ-4.Down { background-position:0px -39px; }

--- a/membership.html
+++ b/membership.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="membership foray newfoundland and labrador">
     <meta name="description" content="Inludes link to download membership registration form.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/mission.html
+++ b/mission.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Mission statement of Foray Newfoundland and Labrador">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/mycophyle_articles.html
+++ b/mycophyle_articles.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Lists articles written by Foray Newfoundland and Labrdor members and published in Mycophile newsletter.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina.html
+++ b/omphalina.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="Omphalina, Foray Newfoundland and Labrador newsletter.">
     <meta name="description" content="Lists Omphalina newsletters by year of publication. Issues are in downloadable and printable PDF.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2010_1.html
+++ b/omphalina_2010_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2011_1.html
+++ b/omphalina_2011_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2012_1.html
+++ b/omphalina_2012_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2013_1.html
+++ b/omphalina_2013_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2014.html
+++ b/omphalina_2014.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2015_1.html
+++ b/omphalina_2015_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphalina_2017_1.html
+++ b/omphalina_2017_1.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/omphaline/page40.html
+++ b/omphaline/page40.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="Current Issue of Omphaliina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="../assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/osprey.html
+++ b/osprey.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Lists articles written by Foray Newfoundland and Labrador members published in Osprey newsletter.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/page36.html
+++ b/page36.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/page37.html
+++ b/page37.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="  Omphaliina vol 9 #9, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/page38.html
+++ b/page38.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="Current Issue of Omphaliina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/page39.html
+++ b/page39.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="Current Issue of Omphaliina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/page40.html
+++ b/page40.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="omphalina, mushrooms, mycology, Newfoundland and Labrador.">
     <meta name="description" content="Current Issue of Omphaliina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/resources.html
+++ b/resources.html
@@ -16,8 +16,8 @@
     <meta name="viewport" content="width=1024">
     <meta name="description" content="Contains links to publications and to lists of Websites useful to Foray NL membership.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/science.html
+++ b/science.html
@@ -15,8 +15,8 @@
     <meta name="generator" content="Serif WebPlus X7">
     <meta name="viewport" content="width=1024">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/search.html
+++ b/search.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="search omphalina, mushrooms, mycology, Newfoundland and Labrador, digital archives.">
     <meta name="description" content="Search back issues of Omphalina via Memorial University's Digital Archives Iniative.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/species_list_by_foray.html
+++ b/species_list_by_foray.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, Foray NL, Newfoundland and labrador, mycology">
     <meta name="description" content="2016 issues of Omphalina, the newsletter of Foray Newfoundland and Labrador.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/species_list_explanations.html
+++ b/species_list_explanations.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="mushrooms, newfoundland and labrador, foray newfoundland and labrador, foray">
     <meta name="description" content="Species list of mushrooms collected by Foray Newfoundland and Labrador during Foarays from 2003 to 2014.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/species_lists.html
+++ b/species_lists.html
@@ -17,8 +17,8 @@
     <meta name="keywords" content="newfoundland mushrooms cumulative index">
     <meta name="description" content="Annotated cumulative index for mushrooms collected and catalogued during forays 2003-present.">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }

--- a/submission_guidelines.html
+++ b/submission_guidelines.html
@@ -15,8 +15,8 @@
     <meta name="generator" content="Serif WebPlus X7">
     <meta name="viewport" content="width=1024">
     <link rel="stylesheet" type="text/css" href="_wp_scripts/wpstyles.css">
-    <style type="text/css">
-      .OBJ-1 { background:transparent url('_wp_generated/wpb765fade_06.png') no-repeat 34px 0px; }
+    <link rel="stylesheet" href="assets/styles/main.css">
+<style type="text/css">
       .OBJ-2,.OBJ-2:link,.OBJ-2:visited { background-image:url('_wp_generated/wpf1b9b58b_06.png');background-repeat:no-repeat;background-position:0px 0px;text-decoration:none;display:block;position:absolute; }
       .OBJ-2:hover { background-position:0px -78px; }
       .OBJ-2:active,a:link.OBJ-2.Activated,a:link.OBJ-2.Down,a:visited.OBJ-2.Activated,a:visited.OBJ-2.Down,.OBJ-2.Activated,.OBJ-2.Down { background-position:0px -39px; }


### PR DESCRIPTION
## Summary
- centralize navigation background styling in new `assets/styles/main.css`
- link shared stylesheet across all pages and remove duplicated inline rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4e9681e48321ab566be1477608f1