### PR TITLE
Refactor navigation with semantic HTML and shared template

### DIFF
--- a/_wp_scripts/navigation.js
+++ b/_wp_scripts/navigation.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var path = window.location.pathname;
+  var link = document.querySelector('#main-nav a[href="' + path + '"]');
+  if (link) {
+    link.setAttribute('aria-current', 'page');
+  }
+});

--- a/_wp_scripts/wpstyles.css
+++ b/_wp_scripts/wpstyles.css
@@ -12,3 +12,35 @@ a:active {color:#0000ff;text-decoration:underline;}
 .Default { text-align:left;margin:0px;text-indent:0.0px;line-height:1px;font-family:"Excelsior LT", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
 .Normal { text-align:left;margin:0px;text-indent:0.0px;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
 .Normal2 { text-align:left;margin:0px;text-indent:0.0px;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
+/* Navigation */
+#main-nav {
+  background-color: #ffa64c;
+}
+.nav-list {
+  list-style: none;
+  display: flex;
+  margin: 0;
+  padding: 0;
+}
+.nav-list li {
+  margin: 0;
+}
+.nav-list a {
+  display: block;
+  padding: 10px 15px;
+  color: #000;
+  text-decoration: none;
+}
+.nav-list a:hover,
+.nav-list a:focus {
+  background-color: #e67400;
+  color: #fff;
+}
+.nav-list a:focus {
+  outline: 2px solid #000;
+  outline-offset: 2px;
+}
+.nav-list a[aria-current="page"] {
+  font-weight: bold;
+  text-decoration: underline;
+}

--- a/about_us.html
+++ b/about_us.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -100,50 +101,34 @@
       .P-4 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:2700px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:2700px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_5" style="position:absolute;left:40px;top:261px;width:938px;height:128px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-2">What is Foray Newfoundland and Labrador?</span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-2"><span class="C-3">Foray Newfoundland and Labrador is a not-<wbr>for-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada.</span></p>
+        <p class="Normal P-2"><span class="C-3">Foray Newfoundland and Labrador is a not-<wbr>for-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada.</wbr></wbr></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
@@ -158,111 +143,15 @@
         <p class="Normal P-4"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_88" style="position:absolute;left:42px;top:2540px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/articles_fungi_magazine.html
+++ b/articles_fungi_magazine.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -118,64 +119,48 @@
       .P-7 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-8 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_23" style="position:absolute;left:41px;top:264px;width:938px;height:452px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Fungi Magazine</span></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><a href="articles/AscoPaper.pdf" target="_blank" class="C-4">Bunyard B, Wang Z, Malloch D, Clayden S, Voitk A: </a><a href="articles/AscoPaper.pdf" target="_blank" class="C-5">New North American Records for Ascocoryne turfi cola (Ascomycota: Helotiales)</a><a href="articles/AscoPaper.pdf" target="_blank" class="C-6">. Fungi 1(2):23-<wbr>31; 2008.</a></p>
+        <p class="Normal P-3"><a href="articles/AscoPaper.pdf" target="_blank" class="C-4">Bunyard B, Wang Z, Malloch D, Clayden S, Voitk A: </a><a href="articles/AscoPaper.pdf" target="_blank" class="C-5">New North American Records for Ascocoryne turfi cola (Ascomycota: Helotiales)</a><a href="articles/AscoPaper.pdf" target="_blank" class="C-6">. Fungi 1(2):23-<wbr>31; 2008.</wbr></a></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><a class="C-4">Knight S, Reid E, Campbell C, Burzynski M, Voitk A: <span class="C-5">Test of the May Model I: community ecologic studies of mushroom foray results in the same and different regions</span>. Fungi 1(4)54-<wbr>58;2008. </a></p>
+        <p class="Normal P-3"><a class="C-4">Knight S, Reid E, Campbell C, Burzynski M, Voitk A: <span class="C-5">Test of the May Model I: community ecologic studies of mushroom foray results in the same and different regions</span>. Fungi 1(4)54-<wbr>58;2008. </wbr></a></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><a href="articles/Slugzz.pdf" target="_blank" class="C-4">Maunder JE, Voitk AJ: <span class="C-5">What we don't know about slugs &amp; mushrooms!</span> Fungi 3(3):36-<wbr>44; 2010</a></p>
+        <p class="Normal P-3"><a href="articles/Slugzz.pdf" target="_blank" class="C-4">Maunder JE, Voitk AJ: <span class="C-5">What we don't know about slugs &amp; mushrooms!</span> Fungi 3(3):36-<wbr>44; 2010</wbr></a></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><a class="C-4">Ohenoja E, Wang Z, Townsend JP, Mitchel D, Voitk A: <span class="C-5">Northern species of earth tongue genus Thuemenidium revisited, considering morphology, ecology and molecular phylogeny.</span> Mycologia 102:1089-<wbr>1095; 2010</a></p>
+        <p class="Normal P-3"><a class="C-4">Ohenoja E, Wang Z, Townsend JP, Mitchel D, Voitk A: <span class="C-5">Northern species of earth tongue genus Thuemenidium revisited, considering morphology, ecology and molecular phylogeny.</span> Mycologia 102:1089-<wbr>1095; 2010</wbr></a></p>
         <p class="Normal P-3"><a class="C-4"><br></a></p>
-        <p class="Normal P-3"><span class="C-3">Voitk &nbsp;AJ, Ohenoja E: <a class="C-5">Genus Multiclavula in Newfoundland and Labrador</a><a class="C-6">.</a> FUNGI 4(2):26-<wbr>31; 2011</span></p>
+        <p class="Normal P-3"><span class="C-3">Voitk  AJ, Ohenoja E: <a class="C-5">Genus Multiclavula in Newfoundland and Labrador</a><a class="C-6">.</a> FUNGI 4(2):26-<wbr>31; 2011</wbr></span></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
         <p class="Normal P-3"><a href="publications/2015-1%20Tricholomopsis.pdf" class="C-4">Saar, Irja &amp; Voitk, Andrus; <span class="C-5">Type studies of two Tricholomopsis species described by Peck.</span> Mycol Progress (2015) 14:46</a></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="DefaultParagraph P-4"><a href="articles/NLF07.pdf" target="_blank" class="C-4">Bunyard B: <span class="C-5">Foray 2007 Newfoundland and Labrador</span>. FUNGI 1:44-<wbr>45;2008.</a></p>
+        <p class="DefaultParagraph P-4"><a href="articles/NLF07.pdf" target="_blank" class="C-4">Bunyard B: <span class="C-5">Foray 2007 Newfoundland and Labrador</span>. FUNGI 1:44-<wbr>45;2008.</wbr></a></p>
         <p class="DefaultParagraph"><span class="C-3"><br></span></p>
-        <p class="DefaultParagraph P-5"><a href="articles/VikFor-Fungi.pdf" target="_blank" class="C-4">Burzynski M, Marceau A, Graham J, Voitk M, Voitk A: <span class="C-5">Pick the mushrooms that the Vikings picked: foray 2010.</span> Fungi 3(2):60-<wbr>61; 2010</a></p>
+        <p class="DefaultParagraph P-5"><a href="articles/VikFor-Fungi.pdf" target="_blank" class="C-4">Burzynski M, Marceau A, Graham J, Voitk M, Voitk A: <span class="C-5">Pick the mushrooms that the Vikings picked: foray 2010.</span> Fungi 3(2):60-<wbr>61; 2010</wbr></a></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
         <p class="Normal P-6"><span class="C-7"><br></span></p>
         <p class="Normal P-6"><span class="C-7"><br></span></p>
@@ -186,112 +171,15 @@
         <p class="Normal P-8"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_111" style="position:absolute;left:35px;top:764px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton Down" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B7M_L1']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/board.html
+++ b/board.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -100,44 +101,28 @@
       .P-5 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:950px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:950px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
 
       <div class="OBJ-8" id="txt_8" style="position:absolute;left:41px;top:278px;width:348px;height:491px;overflow:hidden;">
@@ -166,112 +151,15 @@
         <p class="Normal P-5"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:42px;top:784px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton Down" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B8M_L3']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/bylaws.html
+++ b/bylaws.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -103,50 +104,34 @@
       .P-4 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:700px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:700px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_9" style="position:absolute;left:45px;top:261px;width:933px;height:183px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-1"><span class="C-1">By Laws</span></p>
         <p class="Normal P-2"><span class="C-2"><br></span></p>
-        <p class="Normal P-2"><a class="C-3">Mushroom Foray Newfoundland and Labrador Inc. By-<wbr>Laws</a></p>
+        <p class="Normal P-2"><a class="C-3">Mushroom Foray Newfoundland and Labrador Inc. By-<wbr>Laws</wbr></a></p>
         <p class="Normal P-2"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Policy and Procedures Manual </span></p>
       </div>
@@ -156,112 +141,15 @@
         <p class="Normal P-4"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:478px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton Down" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B8M_L4']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/consultants.html
+++ b/consultants.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -103,44 +104,28 @@
       .P-7 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:650px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:650px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_10" style="position:absolute;left:26px;top:261px;width:953px;height:210px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -150,7 +135,7 @@
         <p class="Normal P-2"><span class="C-1"><br></span></p>
         <p class="Normal P-4"><span class="C-3">Accountants:<span class="C-1"> Gordon Janes, of Bonnell, Cole, Janes in Corner Brook, NL</span></span></p>
         <p class="Normal P-2"><span class="C-1"><br></span></p>
-        <p class="Normal P-4"><span class="C-3">Legal Counsel:<span class="C-1"> &nbsp;Andrew May, Brothers &amp; Burden, Corner Brook, NL</span></span></p>
+        <p class="Normal P-4"><span class="C-3">Legal Counsel:<span class="C-1">  Andrew May, Brothers &amp; Burden, Corner Brook, NL</span></span></p>
         <p class="Normal P-5"><span class="C-1"><br></span></p>
       </div>
       <div id="txt_164" style="position:absolute;left:41px;top:517px;width:951px;height:84px;overflow:hidden;">
@@ -159,112 +144,15 @@
         <p class="Normal P-7"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:41px;top:516px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton Down" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B8M_L5']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/contacts.html
+++ b/contacts.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -104,44 +105,28 @@
       .P-8 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-5 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_219" style="position:absolute;left:518px;top:286px;width:349px;height:342px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
@@ -155,16 +140,16 @@
         <p class="Normal P-4"><span class="C-4"><br></span></p>
         <p class="Normal P-4"><span class="C-4">By Mail:</span></p>
         <p class="Normal P-5"><span class="C-2"><br></span></p>
-        <p class="Normal P-5"><span class="C-2">Foray &nbsp;Newfoundland and Labrador</span></p>
+        <p class="Normal P-5"><span class="C-2">Foray  Newfoundland and Labrador</span></p>
         <p class="Normal P-5"><span class="C-2">16 Brown’s Lane</span></p>
         <p class="Normal P-5"><span class="C-2">Torbay, NL</span></p>
         <p class="Normal P-5"><span class="C-2">A1K 1J1</span></p>
         <p class="Normal P-5"><span class="C-2">CANADA</span></p>
         <p class="Normal P-5"><span class="C-2"><br></span></p>
-        <p class="Normal P-6"><span class="C-4">TELEPHONE: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="C-2">709-<wbr>437-<wbr>5097</span></span></p>
+        <p class="Normal P-6"><span class="C-4">TELEPHONE:       <span class="C-2">709-<wbr>437-<wbr>5097</wbr></wbr></span></span></p>
         <p class="Normal P-5"><span class="C-2"><br></span></p>
         <p class="Normal P-5"><span class="C-2"><br></span></p>
-        <p class="Normal P-4"><span class="C-4">E-<wbr>MAIL<span class="C-2">: &nbsp;<a href="mailto:info@nlmushrooms.ca" class="C-3">info@nlmushrooms.ca</a></span></span></p>
+        <p class="Normal P-4"><span class="C-4">E-<wbr>MAIL<span class="C-2">:  <a href="mailto:info@nlmushrooms.ca" class="C-3">info@nlmushrooms.ca</a></span></wbr></span></p>
         <p class="Normal P-5"><span class="C-2"><br></span></p>
         <p class="Normal P-1"><span class="C-1"><br></span></p>
       </div>
@@ -174,112 +159,15 @@
         <p class="Normal P-8"><span class="C-5">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:40px;top:777px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton Down" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B8M_L1']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/current issue.html
+++ b/current issue.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -108,44 +109,28 @@
       .P-10 { text-align:center;margin-right:22.3px;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-6 { line-height:34.50px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1550px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1550px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:17px;top:275px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -165,7 +150,7 @@
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><span class="C-4">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Back Issues 2022-<wbr>23</span></p>
+        <p class="Normal P-3"><span class="C-4">               Back Issues 2022-<wbr>23</wbr></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="DefaultParagraph P-4"><span class="C-1"><br></span></p>
       </div>
@@ -189,7 +174,7 @@
         <p class="Normal2 P-9"><span class="C-3">Many fungi collected in Newfoundland and Labrador have been covered in articles written for Omphalina, the newsletter of Foray Newfoundland and Labrador. The content of back issues of Omphalina are indexed by authors, topic , fungi species and a running tally in a Microsoft Excel spreadsheet. that can be downloaded via the link below.</span></p>
         <p class="Normal2 P-9"><span class="C-3"><br></span></p>
         <p class="Normal2 P-8"><span class="C-3"><br></span></p>
-        <p class="Normal2 P-10"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-6">Spreadshseet of Indicies of topics, &nbsp;authors and species covered in Omphalina</a></p>
+        <p class="Normal2 P-10"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-6">Spreadshseet of Indicies of topics,  authors and species covered in Omphalina</a></p>
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
       </div>
       <a href="omphaline/O-13-1.pdf" target="_blank">
@@ -207,112 +192,15 @@
       <a href="https://drive.google.com/file/d/16zo92TFDbQP90_7fJKELq_X6ZDAJiNbJ/view" target="_blank">
         <img alt="" src="_wp_generated/wpcecd6281_06.png" id="pic_238" style="position:absolute;left:634px;top:325px;width:267px;height:347px;">
       </a>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L2']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/facebook_links.html
+++ b/facebook_links.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -95,44 +96,28 @@
       .P-2 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-2 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1400px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1400px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_162" style="position:absolute;left:247px;top:274px;width:718px;height:937px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -159,112 +144,15 @@
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_93" style="position:absolute;left:36px;top:1252px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton Down" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B7M_L3']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/flickr_image_index.html
+++ b/flickr_image_index.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -124,44 +125,28 @@
       .P-21 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-22 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1400px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1400px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_111" style="position:absolute;left:32px;top:416px;width:344px;height:813px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
@@ -247,112 +232,15 @@
         <p class="Normal P-22"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_98" style="position:absolute;left:36px;top:1275px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B4M_L3']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/flickr_voucher_images.html
+++ b/flickr_voucher_images.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -98,44 +99,28 @@
       .C-3 { line-height:20.00px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-5 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1014px;height:1000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_165" style="position:absolute;left:37px;top:278px;width:956px;height:243px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -169,112 +154,15 @@
         <p class="Normal P-5"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_109" style="position:absolute;left:37px;top:871px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B4M_L4']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/foray_2023.html
+++ b/foray_2023.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -106,44 +107,28 @@
       .P-9 { margin-left:51.0px;text-indent:-2.0px;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .C-6 { line-height:20.00px;font-family:"Times New Roman", serif;font-style:italic;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1012px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1012px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div id="txt_164" style="position:absolute;left:44px;top:872px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
@@ -164,7 +149,7 @@
         <p class="Normal P-7"><span class="C-1"><br></span></p>
         <p class="Normal P-8"><a href="foray_information/Foray_General_Information.pdf" target="_blank" class="C-5">General Information</a></p>
         <p class="Normal P-8"><span class="C-1"><br></span></p>
-        <p class="Normal P-9"><span class="C-1">What happens at a Foray? Click on this <a href="omphaline/Omphalina%20IX%209.pdf" target="_blank" class="C-5">Foray Report 2019 </a>&nbsp;to learn more.</span></p>
+        <p class="Normal P-9"><span class="C-1">What happens at a Foray? Click on this <a href="omphaline/Omphalina%20IX%209.pdf" target="_blank" class="C-5">Foray Report 2019 </a> to learn more.</span></p>
         <p class="Normal P-9"><span class="C-1"><br></span></p>
         <p class="Normal P-9"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5">Clothing, Supplies, Equipment and Safety Information.</a></p>
         <p class="Normal P-9"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
@@ -176,111 +161,15 @@
         <p class="Normal"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
       </div>
       <img alt="" src="_wp_generated/wp81bc60e1_05_06.jpg" id="pic_232" style="position:absolute;left:20px;top:271px;width:418px;height:540px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/foray_2024.html
+++ b/foray_2024.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -134,44 +135,28 @@
         color: #0000ff
       }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1012px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
+
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1012px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="Foray NL Logo Banner" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div id="txt_164" style="position:absolute;left:44px;top:872px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
@@ -200,7 +185,7 @@
         <p class="Normal P-7"><span class="C-1"><br></span></p>
         <p class="Normal P-8"><a href="foray_information/Foray_General_Information.pdf" target="_blank" class="C-5">General Information</a></p>
         <p class="Normal P-8"><span class="C-1"><br></span></p>
-        <p class="Normal P-9"><span class="C-1">What happens at a Foray? Click on this <a href="omphaline/Omphalina%20IX%209.pdf" target="_blank" class="C-5">Foray Report 2019 </a>&nbsp;to learn more.</span></p>
+        <p class="Normal P-9"><span class="C-1">What happens at a Foray? Click on this <a href="omphaline/Omphalina%20IX%209.pdf" target="_blank" class="C-5">Foray Report 2019 </a> to learn more.</span></p>
         <p class="Normal P-9"><span class="C-1"><br></span></p>
         <p class="Normal P-9"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5">Clothing, Supplies, Equipment and Safety Information.</a></p>
         <p class="Normal P-9"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
@@ -214,111 +199,15 @@
         <p class="Normal"><a href="foray_information/Clothing_Supplies_and_Equipment2.pdf" target="_blank" class="C-5"><br></a></p>
       </div>
       <img alt="Foray 2024 Poster" src="images/foray2024_poster.png" id="pic_232" style="position:absolute;left:20px;top:271px;width:418px;height:540px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+<script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/foray_2025.html
+++ b/foray_2025.html
@@ -1,12 +1,13 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="UTF-8">
   <title>Foray 2025</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="keywords" content="mushrooms, foray, newfoundland and labrador">
   <meta name="description" content="Foray Newfoundland and Labrador 2025">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tahoma:400,700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tahoma:400,700&amp;display=swap">
   <style>
     body {
       font-family: "Tahoma", Arial, sans-serif;
@@ -114,6 +115,20 @@
   </style>
 </head>
 <body>
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
   <header>
     <img src="_wp_generated/wp1da48039_05_06.jpg" alt="Foray NL Logo Banner">
   </header>
@@ -185,5 +200,6 @@
       Email: <a href="mailto:webmaster@nlmushrooms.ca">webmaster@nlmushrooms.ca</a>
     </p>
   </footer>
+<script src="/_wp_scripts/navigation.js"></script>
 </body>
 </html>

--- a/foray_reports.html
+++ b/foray_reports.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -110,50 +111,32 @@
       .P-9 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-5 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:750px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:750px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_13" style="position:absolute;left:247px;top:280px;width:733px;height:282px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Foray Reports</span></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-4">Annual Reports for the years 2003-<wbr>2016, inclusive, are available for download as PDF files. Annual Reports from 2012 to present are published on a special issue of Omphalina.</p>
+        <p class="Normal P-4">Annual Reports for the years 2003-<wbr>2016, inclusive, are available for download as PDF files. Annual Reports from 2012 to present are published on a special issue of Omphalina.</wbr></p>
         <p class="Normal P-5">About Our Reports</p>
         <p class="Normal P-6">Our Foray Reports document the events, faculty, participants and trails of the foray. It includes the program and articles related to the foray. It also includes the species collected and their distribution along the trails and a commentary on what was achieved and what was learned.</p>
         <p class="Normal P-6">Our reports also list our partners. Without their support this work would not have happened.</p>
@@ -166,111 +149,14 @@
         <p class="Normal P-9"><span class="C-5">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_89" style="position:absolute;left:36px;top:599px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/foray_reports_all.html
+++ b/foray_reports_all.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -111,44 +112,26 @@
       .P-9 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-9 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:5000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:5000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:32px;top:705px;width:948px;height:3436px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -245,9 +228,9 @@
         <p class="Normal P-2"><span class="C-3">Gros Morne National Park</span></p>
       </div>
       <div id="txt_155" style="position:absolute;left:52px;top:2300px;width:899px;height:106px;overflow:hidden;">
-        <p class="DefaultParagraph"><span class="C-4">Other Foray &nbsp;Reports:</span></p>
+        <p class="DefaultParagraph"><span class="C-4">Other Foray  Reports:</span></p>
         <p class="Normal"><span class="C-4"><br></span></p>
-        <p class="Normal"><span class="C-3">The following foray reports are from Faculty Forays or mini-<wbr>Forays held by Foray NL just before the annual Foray or during other times of the year.</span></p>
+        <p class="Normal"><span class="C-3">The following foray reports are from Faculty Forays or mini-<wbr>Forays held by Foray NL just before the annual Foray or during other times of the year.</wbr></span></p>
         <p class="Normal"><span class="C-4"><br></span></p>
       </div>
       <a href="omphaline/O-IV-10.pdf" target="_blank">
@@ -304,112 +287,14 @@
       <div id="txt_239" style="position:absolute;left:48px;top:2232px;width:200px;height:28px;overflow:hidden;">
         <p class="DefaultParagraph P-2"><span class="C-3">2019 &amp; Central NL</span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton Down" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B3M_L1']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/fungal_websites.html
+++ b/fungal_websites.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -110,44 +111,26 @@
       .C-9 { line-height:30.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .OBJ-8 { background:#ffa64c; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1500px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1500px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_182" style="position:absolute;left:32px;top:278px;width:969px;height:1077px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -198,112 +181,14 @@
         <p class="Normal2 P-7"><a href="http://www.sciencedaily.com/news/plants_animals/fungus/" target="_blank" class="C-9"><br></a></p>
         <p class="Normal P-1"><span class="C-3"><br></span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton Down" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B7M_L5']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
     <script>
@@ -132,14 +133,24 @@
       .OBJ-9:active span,a:link.OBJ-9.Activated span,a:link.OBJ-9.Down span,a:visited.OBJ-9.Activated span,a:visited.OBJ-9.Down span,.OBJ-9.Activated span,.OBJ-9.Down span { color:#636363; }
       .OBJ-9.Disabled span,a:link.OBJ-9.Disabled span,a:visited.OBJ-9.Disabled span,a:hover.OBJ-9.Disabled span,a:active.OBJ-9.Disabled span { color:#636363; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1450px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1450px;">
       <div id="txt_121" style="position:absolute;left:36px;top:263px;width:951px;height:40px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1">Mouse over the buttons on the navigation bar above and click on an item or on an option from the pull down menu if it appears.</span></p>
@@ -152,7 +163,7 @@
       <img alt="" src="_wp_generated/wp993d91bd_06.png" id="img_87" style="position:absolute;left:24px;top:1300px;width:975px;height:3px;">
       <div class="OBJ-1" id="txt_22" style="position:absolute;left:23px;top:830px;width:674px;height:453px;overflow:hidden;">
         <p class="Normal P-4"><span class="C-2"><br></span></p>
-        <p class="Normal P-5"><span class="C-4">Voitk, A: &nbsp;&nbsp;A Little Illustrated Book of Common Mushrooms of Newfoundland and Labrador. ISBN 978-<wbr>0-<wbr>9699509-<wbr>4-<wbr>3</span></p>
+        <p class="Normal P-5"><span class="C-4">Voitk, A:   A Little Illustrated Book of Common Mushrooms of Newfoundland and Labrador. ISBN 978-<wbr>0-<wbr>9699509-<wbr>4-<wbr>3</wbr></wbr></wbr></wbr></span></p>
         <p class="Normal P-6"><span class="C-5"><br></span></p>
         <p class="Normal P-7"><span class="C-4">ORDER FROM:<span class="C-6"> </span></span></p>
         <p class="Normal P-8"><span class="C-6"><br></span></p>
@@ -160,8 +171,8 @@
         <p class="Normal P-7"><span class="C-4">PO Box 130</span></p>
         <p class="Normal P-7"><span class="C-4">Rocky Harbour, NL, A0K 4N0, Canada</span></p>
         <p class="Normal P-8"><span class="C-6"><br></span></p>
-        <p class="Normal P-8"><span class="C-6">Tel: 709-<wbr>458-<wbr>3610 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Fax: 709-<wbr>458-<wbr>2162</span></p>
-        <p class="Normal P-8"><span class="C-6">E-<wbr>mail: jackie.hiscock@pc.gc.ca</span></p>
+        <p class="Normal P-8"><span class="C-6">Tel: 709-<wbr>458-<wbr>3610          Fax: 709-<wbr>458-<wbr>2162</wbr></wbr></wbr></wbr></span></p>
+        <p class="Normal P-8"><span class="C-6">E-<wbr>mail: jackie.hiscock@pc.gc.ca</wbr></span></p>
         <p class="Normal P-8"><span class="C-6"><br></span></p>
         <p class="Normal P-8"><span class="C-6">MasterCard or VISA preferred by phone.</span></p>
         <p class="Normal P-8"><span class="C-6"><br></span></p>
@@ -182,7 +193,7 @@
         <p class="Normal P-9"><span class="C-7"><br></span></p>
         <p class="Normal P-9"><span class="C-7"><br></span></p>
         <p class="Normal P-10"><span class="C-8"><br></span></p>
-        <p class="DefaultParagraph P-11"><span class="C-9">Foray Newfoundland and Labrador is a non-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada. The resources our web site offers are listed across the navigation bar above.</span></p>
+        <p class="DefaultParagraph P-11"><span class="C-9">Foray Newfoundland and Labrador is a non-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada. The resources our web site offers are listed across the navigation bar above.</wbr></span></p>
         <p class="Normal P-12"><span class="C-10"><br></span></p>
       </div>
       <div class="OBJ-1" id="txt_116" style="position:absolute;left:724px;top:302px;width:281px;height:761px;overflow:hidden;">
@@ -191,14 +202,14 @@
         <p class="DefaultParagraph P-14"><span class="C-3"><img alt="" src="_wp_generated/wp11143d05_05_06.jpg" id="pic_234" style="float:left;margin:6px;width:248px;height:358px;"></span><span class="C-4">Size: <span class="C-6">22 x 32 in, / 56 x 81 cm</span></span></p>
         <p class="Normal P-15"><span class="C-4"><br></span></p>
         <p class="DefaultParagraph P-15"><span class="C-4">Available from</span></p>
-        <p class="DefaultParagraph P-16"><span class="C-6">Gros Morne Co-<wbr>operating Association stores at the Visitor Reception Centre</span></p>
+        <p class="DefaultParagraph P-16"><span class="C-6">Gros Morne Co-<wbr>operating Association stores at the Visitor Reception Centre</wbr></span></p>
         <p class="Normal P-16"><span class="C-6">Rocky Harbour) &amp; Discovery Centre (Woody Point)</span></p>
         <p class="Normal P-15"><span class="C-4"><br></span></p>
         <p class="Normal2 P-17">Mail Order From Gros Morne</p>
         <p class="Normal2 P-18">Poster, including Shipping, Postage &amp; Mailing tube</p>
         <p class="Normal2 P-18">$16.00, taxes included</p>
-        <p class="Normal P-19"><span class="C-4">E-<wbr>mail<span class="C-6">: </span></span><a href="mailto:darlene@gmist.ca" class="C-11">darlene@gmist.ca<span class="C-12"><br></span></a><span class="C-2"><br></span></p>
-        <p class="DefaultParagraph P-20">Tel<span class="C-13">: 709-<wbr>458-<wbr>3605</span></p>
+        <p class="Normal P-19"><span class="C-4">E-<wbr>mail<span class="C-6">: </span></wbr></span><a href="mailto:darlene@gmist.ca" class="C-11">darlene@gmist.ca<span class="C-12"><br></span></a><span class="C-2"><br></span></p>
+        <p class="DefaultParagraph P-20">Tel<span class="C-13">: 709-<wbr>458-<wbr>3605</wbr></wbr></span></p>
       </div>
       <div id="txt_236" style="position:absolute;left:359px;top:744px;width:340px;height:35px;overflow:hidden;">
         <p class="DefaultParagraph P-2"><span class="C-2">Click on the Foray 2025 tab for more information.</span></p>
@@ -207,141 +218,16 @@
       <img alt="" src="_wp_generated/wpb8d4985e_05_06.jpg" id="pic_233" style="position:absolute;left:84px;top:323px;width:202px;height:241px;">
       <img alt="" src="_wp_generated/wp7cfacecc_05_06.jpg" id="pic_235" style="position:absolute;left:423px;top:886px;width:177px;height:283px;">
       <img alt="" src="_wp_generated/wp302e9c15_05_06.jpg" id="pic_236" style="position:absolute;left:723px;top:1094px;width:267px;height:178px;">
-      <div id="nav_4" class="OBJ-3" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-8 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-8 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-8 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-8 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-8 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-9 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-9 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-9 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-9 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-9 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/membership.html
+++ b/membership.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -120,44 +121,26 @@
       .P-15 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-9 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_51" style="position:absolute;left:42px;top:282px;width:920px;height:701px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
@@ -169,13 +152,17 @@
         <p class="Normal P-5"><span class="C-5">Membership is usually paid with foray registration, but is available separately for those unable to participate, but still wishing to be part of the organization. </span></p>
         <p class="Normal P-5"><span class="C-5">Membership is effective from opening day of closest main annual foray following payment to opening day of the subsequent annual foray. <span class="C-6">One fee covers spouse/partner and any underage children, all living at same address.</span></span></p>
         <p class="Normal P-6"><span class="C-6"><br></span></p>
-        <p class="Default P-7"><span class="C-4">Membership fees can also be made via e-<wbr>transfer to &nbsp;<span class="C-7">foraynltreasurer@gmail.com </span>&nbsp;as indicated on the form.</span></p>
+        <p class="Default P-7"><span class="C-4">Membership fees can also be made via e-<wbr>transfer to  <span class="C-7">foraynltreasurer@gmail.com </span> as indicated on the form.</wbr></span></p>
         <p class="Normal P-8"><span class="C-4"><br></span></p>
         <p class="Normal P-9"><br></p>
         <p class="Normal2 P-10"><span class="C-2">Benefits of Membership</span></p>
         <p class="Normal2 P-10"><span class="C-2"><br></span></p>
         <ul style="list-style-type:disc;margin:0;padding:0;">
-          <li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Advance notice of Foray (last few years we have not been able to accommodate all registrants). </span></li><li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Kept informed of forays and activities of FORAY NEWFOUNDLAND &amp; LABRADOR. </span></li><li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Year's subscription to OMPHALINA, the electronic newsletter/journal of FNL. </span></li><li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">A direct voice in how the foray is run and who runs it. </span></li><li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Add your voice to the number of organized naturalists interested in our nature.</span></li>
+          <li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Advance notice of Foray (last few years we have not been able to accommodate all registrants). </span></li>
+<li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Kept informed of forays and activities of FORAY NEWFOUNDLAND &amp; LABRADOR. </span></li>
+<li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Year's subscription to OMPHALINA, the electronic newsletter/journal of FNL. </span></li>
+<li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">A direct voice in how the foray is run and who runs it. </span></li>
+<li class="Normal2 P-11" style="text-indent:0;margin-left:48.0px;"><span class="C-5">Add your voice to the number of organized naturalists interested in our nature.</span></li>
         </ul>
         <p class="Normal P-12"><br></p>
         <p class="Normal P-10"><a class="C-8"><br></a></p>
@@ -191,111 +178,14 @@
         <p class="Normal P-15"><span class="C-9">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_100" style="position:absolute;left:36px;top:1066px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/mission.html
+++ b/mission.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -109,48 +110,30 @@
       .P-11 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-12 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_5" style="position:absolute;left:38px;top:259px;width:947px;height:81px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
-        <p class="Normal P-1"><span class="C-2">Foray Newfoundland and Labrador is a not-<wbr>for-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada.</span></p>
+        <p class="Normal P-1"><span class="C-2">Foray Newfoundland and Labrador is a not-<wbr>for-<wbr>profit organization conducting amateur mushroom forays in the province of Newfoundland and Labrador, Canada.</wbr></wbr></span></p>
         <p class="Normal"><span class="C-1"><br></span></p>
       </div>
       <div class="OBJ-8" id="txt_6" style="position:absolute;left:38px;top:357px;width:387px;height:503px;overflow:hidden;">
@@ -161,18 +144,27 @@
         <p class="Normal P-4"><span class="C-4"><br></span></p>
         <p class="Normal P-3"><span class="C-3">Vision</span></p>
         <p class="Normal P-4"><span class="C-4"><br></span></p>
-        <p class="Normal P-4"><span class="C-4">&nbsp;A society which values the pleasure derived from the scientific, aesthetic, spiritual and gastronomic enjoyment of mushrooms as an important, interesting and integral part of nature, pursued in their natural setting in the company of peers with similar curiosity and interest.</span></p>
+        <p class="Normal P-4"><span class="C-4"> A society which values the pleasure derived from the scientific, aesthetic, spiritual and gastronomic enjoyment of mushrooms as an important, interesting and integral part of nature, pursued in their natural setting in the company of peers with similar curiosity and interest.</span></p>
         <p class="Normal P-5"><span class="C-1"><br></span></p>
-        <p class="Normal P-2"><span class="C-1">&nbsp;</span></p>
+        <p class="Normal P-2"><span class="C-1"> </span></p>
       </div>
       <div class="OBJ-8" id="txt_7" style="position:absolute;left:438px;top:356px;width:550px;height:503px;overflow:hidden;">
         <p class="Normal P-6"><span class="C-1"><br></span></p>
         <p class="Normal P-7"><span class="C-3">Values</span></p>
         <p class="Normal P-8"><span class="C-5"><br></span></p>
         <ul style="list-style-type:disc;margin:0;padding:0;">
-          <li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Make mushroom forays appealing and accessible to all at reasonable cost.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Strive for a sense of fellowship and camaraderie at forays and meetings.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Provide fodder for diverse interests of foray participants.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Identify and document Newfoundland and Labrador Mycota reliably.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Disseminate knowledge about mushrooms through forays, talks, writings, media.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Promote interest in mushrooms through forays, media.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Promote interest in mushrooms among youth by supporting the participation of children, youths and students at our forays.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Learn through review of our findings.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Teach through publication of our findings.</span></li><li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Share our findings, data and specimens with interested investigators &nbsp;worldwide.</span></li>
+          <li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Make mushroom forays appealing and accessible to all at reasonable cost.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Strive for a sense of fellowship and camaraderie at forays and meetings.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Provide fodder for diverse interests of foray participants.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Identify and document Newfoundland and Labrador Mycota reliably.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Disseminate knowledge about mushrooms through forays, talks, writings, media.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Promote interest in mushrooms through forays, media.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Promote interest in mushrooms among youth by supporting the participation of children, youths and students at our forays.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Learn through review of our findings.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Teach through publication of our findings.</span></li>
+<li class="Normal P-9" style="text-indent:0;margin-left:28.1px;"><span class="C-5">Share our findings, data and specimens with interested investigators  worldwide.</span></li>
         </ul>
-        <p class="Normal P-10"><span class="C-6">&nbsp;</span></p>
+        <p class="Normal P-10"><span class="C-6"> </span></p>
         <p class="Normal P-6"><span class="C-1"><br></span></p>
       </div>
       <div id="txt_164" style="position:absolute;left:36px;top:879px;width:951px;height:84px;overflow:hidden;">
@@ -181,112 +173,14 @@
         <p class="Normal P-12"><span class="C-3">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:36px;top:877px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton Down" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B8M_L2']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/mycophyle_articles.html
+++ b/mycophyle_articles.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -126,44 +127,26 @@
       .P-6 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-9 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_163" style="position:absolute;left:45px;top:271px;width:935px;height:378px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -177,7 +160,7 @@
         <p class="DefaultParagraph P-2"><a href="articles/pentangulospora.pdf" target="_blank" class="C-4"><br></a></p>
         <p class="DefaultParagraph P-2"><a href="articles/pentangulospora.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">A new pinkspored genus and two new cryptic species</span>. Mycophile 48:1; 2007</a></p>
         <p class="DefaultParagraph P-2"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-2"><a href="articles/Lichenomphalia2.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Three lichenomphalias from the top of Gros Morne Mountain.</span> Mycophile 47:1...11; 2006 and Osprey 37:78-<wbr>80; 2006.</a></p>
+        <p class="DefaultParagraph P-2"><a href="articles/Lichenomphalia2.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Three lichenomphalias from the top of Gros Morne Mountain.</span> Mycophile 47:1...11; 2006 and Osprey 37:78-<wbr>80; 2006.</wbr></a></p>
         <p class="DefaultParagraph P-2"><span class="C-6"><br></span></p>
         <p class="DefaultParagraph P-2"><span class="C-6">Voitk A: <a class="C-5">Mushroom of the Month: Stropharia alcis.</a><a class="C-7"> Mycophile</a> 47:20; 2006.</span></p>
         <p class="DefaultParagraph P-3"><span class="C-1"><br></span></p>
@@ -191,112 +174,14 @@
         <p class="Normal P-6"><span class="C-9">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_113" style="position:absolute;left:36px;top:717px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton Down" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B7M_L2']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/navigation.html
+++ b/navigation.html
@@ -1,0 +1,13 @@
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>

--- a/omphalina.html
+++ b/omphalina.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -101,55 +102,37 @@
       .P-7 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-2 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_48" style="position:absolute;left:300px;top:280px;width:685px;height:399px;overflow:hidden;">
         <p class="Normal P-1"><br></p>
         <p class="Normal P-2">Omphalina: The Newsletter of Foray Newfoundland and Labrador</p>
         <p class="Normal P-3"><br></p>
-        <p class="Normal P-4">Omphalina began as a vehicle for last-<wbr>minute information about an upcoming Foray. Thanks to many kind contributors, it has evolved into a small journal with short articles of mycological interest.</p>
+        <p class="Normal P-4">Omphalina began as a vehicle for last-<wbr>minute information about an upcoming Foray. Thanks to many kind contributors, it has evolved into a small journal with short articles of mycological interest.</wbr></p>
         <p class="Normal P-4"><br></p>
-        <p class="Normal P-4">Omphalina’s focus is on the mycota of Newfoundland and Labrador, given that there are many good general mycology journals, but none where a Newfoundlander and Labradorean can read about their mushrooms. Even so, Omphalina still keeps its newsletter function, to inform members of Foray-<wbr>related matters and other events. </p>
+        <p class="Normal P-4">Omphalina’s focus is on the mycota of Newfoundland and Labrador, given that there are many good general mycology journals, but none where a Newfoundlander and Labradorean can read about their mushrooms. Even so, Omphalina still keeps its newsletter function, to inform members of Foray-<wbr>related matters and other events. </wbr></p>
         <p class="Normal P-4"><br></p>
         <p class="Normal P-4">Omphalina is emailed to members on publication, and is available free of charge from our web site to the curious among the general public. There is no proscribed number of Volumes/Issues, nor is there a regular expected time of publication. In fact, there is no promise it will ever appear again! </p>
-        <p class="Normal P-5">&nbsp;</p>
+        <p class="Normal P-5"> </p>
       </div>
       <div id="txt_164" style="position:absolute;left:35px;top:791px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-6"><span class="C-1"><br></span></p>
@@ -157,111 +140,14 @@
         <p class="Normal P-7"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_91" style="position:absolute;left:35px;top:789px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2010_1.html
+++ b/omphalina_2010_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -194,112 +177,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_107" style="position:absolute;left:36px;top:1091px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L14']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2011_1.html
+++ b/omphalina_2011_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1500px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1500px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -210,112 +193,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_108" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L13']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2012_1.html
+++ b/omphalina_2012_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1500px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1500px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -228,112 +211,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_105" style="position:absolute;left:36px;top:1399px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L12']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2013_1.html
+++ b/omphalina_2013_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1500px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1500px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -222,112 +205,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_106" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L11']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2014.html
+++ b/omphalina_2014.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1500px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1500px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -222,112 +205,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_104" style="position:absolute;left:36px;top:1391px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L10']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2015_1.html
+++ b/omphalina_2015_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -194,112 +177,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_102" style="position:absolute;left:36px;top:1098px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L9']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphalina_2017_1.html
+++ b/omphalina_2017_1.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -194,112 +177,14 @@
       <a href="omphaline/O-VIII-7.pdf">
         <img alt="O-VIII-7.pdf" src="_wp_generated/wp0a0fe93c_06.png" id="pic_148" style="position:absolute;left:535px;top:683px;width:178px;height:231px;">
       </a>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L7']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/omphaline/page40.html
+++ b/omphaline/page40.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -106,44 +107,26 @@
       .P-9 { text-align:center;margin-right:22.3px;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-5 { line-height:34.50px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1700px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1700px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:22px;top:277px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -163,7 +146,7 @@
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><span class="C-4">&nbsp;</span></p>
+        <p class="Normal P-3"><span class="C-4"> </span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="DefaultParagraph P-4"><span class="C-1"><br></span></p>
       </div>
@@ -197,115 +180,17 @@
         <p class="Normal2 P-8"><span class="C-3">Many fungi collected in Newfoundland and Labrador have been covered in articles written for Omphalina, the newsletter of Foray Newfoundland and Labrador. The content of back issues of Omphalina are indexed by authors, topic , fungi species and a running tally in a Microsoft Excel spreadsheet. that can be downloaded via the link below.</span></p>
         <p class="Normal2 P-8"><span class="C-3"><br></span></p>
         <p class="Normal2 P-7"><span class="C-3"><br></span></p>
-        <p class="Normal2 P-9"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-5">Spreadhseet of Indicies of topocs, &nbsp;authors and species covered in Omphalina</a></p>
+        <p class="Normal2 P-9"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-5">Spreadhseet of Indicies of topocs,  authors and species covered in Omphalina</a></p>
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L3']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/osprey.html
+++ b/osprey.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -119,44 +120,26 @@
       .P-6 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-7 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_163" style="position:absolute;left:46px;top:266px;width:944px;height:761px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
@@ -171,27 +154,27 @@
         <p class="Normal2 P-3"><span class="C-3">Osprey is the magazine of Nature Newfoundland and Labrador (formerly the Newfoundland and Labrador Natural History Society).</span></p>
         <p class="Normal2 P-3"><span class="C-3"><br></span></p>
         <p class="Normal P-2"><span class="C-2"><br></span></p>
-        <p class="DefaultParagraph P-3"><a href="articles/vik-osp.pdf" target="_blank" class="C-4">Burzynski M, Marceau A, Graham J, Voitk M, Voitk A: <span class="C-5">Come, foray with the Vikings!</span> Osprey 41:18-<wbr>19; 2010</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/vik-osp.pdf" target="_blank" class="C-4">Burzynski M, Marceau A, Graham J, Voitk M, Voitk A: <span class="C-5">Come, foray with the Vikings!</span> Osprey 41:18-<wbr>19; 2010</wbr></a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
         <p class="DefaultParagraph P-3"><a href="articles/forcoll.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">The foray collection.</span> Osprey 41:16; 2010</a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-3"><span class="C-6">Voitk A: <a class="C-5">Discussion of the cumulative species curve of Foray Newfoundland &amp; Labrador.</a><a class="C-7"> </a>Osprey 38:131-<wbr>134, 2007</span></p>
+        <p class="DefaultParagraph P-3"><span class="C-6">Voitk A: <a class="C-5">Discussion of the cumulative species curve of Foray Newfoundland &amp; Labrador.</a><a class="C-7"> </a>Osprey 38:131-<wbr>134, 2007</wbr></span></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-3"><a href="articles/panelli332.pdf" target="_blank" class="C-4">Voitk A, Warren G: <span class="C-5">Mycenas of the treetops.</span> Osprey 42(1):12-<wbr>13. 2011</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/panelli332.pdf" target="_blank" class="C-4">Voitk A, Warren G: <span class="C-5">Mycenas of the treetops.</span> Osprey 42(1):12-<wbr>13. 2011</wbr></a></p>
         <p class="DefaultParagraph P-3"><a href="articles/panelli332.pdf" target="_blank" class="C-4"><br></a></p>
-        <p class="DefaultParagraph P-3"><a href="articles/ochrolech.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Ochrolechia frigida (Swartz) Lynge—a cool lichen.</span> Osprey 41(3):19-<wbr>20; 2010</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/ochrolech.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Ochrolechia frigida (Swartz) Lynge—a cool lichen.</span> Osprey 41(3):19-<wbr>20; 2010</wbr></a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
         <p class="DefaultParagraph P-3"><a href="articles/JellyEar.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Auricularia americana—jelly tree ear. </span>Osprey 41:17; 2010</a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
         <p class="DefaultParagraph P-3"><a href="articles/albatrell.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">A bitter trap </span>Osprey 41:13; 2010</a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-3"><a href="articles/multiclav.pdf" target="_blank" class="C-4">Voitk A, Ohenoja E: <span class="C-5">Multiclavula inNewfoundland and Labrador.</span> Osprey 40:26-<wbr>28; 2009</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/multiclav.pdf" target="_blank" class="C-4">Voitk A, Ohenoja E: <span class="C-5">Multiclavula inNewfoundland and Labrador.</span> Osprey 40:26-<wbr>28; 2009</wbr></a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-3"><a href="articles/Tomentella.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">The austere Tomentella.</span> Osprey 40:18-<wbr>21; 2009</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/Tomentella.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">The austere Tomentella.</span> Osprey 40:18-<wbr>21; 2009</wbr></a></p>
         <p class="DefaultParagraph P-3"><span class="C-6"><br></span></p>
-        <p class="DefaultParagraph P-3"><a href="articles/2cups.pdf" class="C-4">Voitk A: <span class="C-5">Two green cups. </span>Osprey 39:117-<wbr>119;2008</a></p>
+        <p class="DefaultParagraph P-3"><a href="articles/2cups.pdf" class="C-4">Voitk A: <span class="C-5">Two green cups. </span>Osprey 39:117-<wbr>119;2008</wbr></a></p>
         <p class="DefaultParagraph P-4"><a href="articles/2cups.pdf" class="C-4"><br></a></p>
-        <p class="DefaultParagraph P-4"><a href="articles/PolyozellusOsprey.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Polyozellus multiplex-<wbr>an example of our mycological ignorance.</span> Osprey 37:20-<wbr>22; 2006.</a></p>
+        <p class="DefaultParagraph P-4"><a href="articles/PolyozellusOsprey.pdf" target="_blank" class="C-4">Voitk A: <span class="C-5">Polyozellus multiplex-<wbr>an example of our mycological ignorance.</wbr></span> Osprey 37:20-<wbr>22; 2006.</wbr></a></p>
         <p class="DefaultParagraph P-5"><span class="C-8"><br></span></p>
         <p class="DefaultParagraph"><span class="C-9"><br></span></p>
       </div>
@@ -201,112 +184,14 @@
         <p class="Normal P-7"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_112" style="position:absolute;left:36px;top:1076px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton Down" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B7M_L4']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/page36.html
+++ b/page36.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -99,44 +100,26 @@
       .P-3 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-4 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:341px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -200,112 +183,14 @@
         <p class="Normal P-3"><span class="C-4">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_103" style="position:absolute;left:36px;top:1081px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L8']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/page37.html
+++ b/page37.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -102,44 +103,26 @@
       .P-5 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-6 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1600px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1600px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:1159px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -223,112 +206,14 @@
       <div id="txt_215" style="position:absolute;left:51px;top:1290px;width:185px;height:42px;overflow:hidden;">
         <p class="DefaultParagraph P-5"><span class="C-1">Vol 9 #9</span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L6']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/page38.html
+++ b/page38.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -104,44 +105,26 @@
       .P-6 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .C-6 { line-height:19.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:454px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -161,7 +144,7 @@
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><span class="C-4">&nbsp;</span></p>
+        <p class="Normal P-3"><span class="C-4"> </span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-2"><a href="omphaline/Omphalina-XI-1.pdf" target="_blank" class="C-5"><br></a></p>
       </div>
@@ -200,112 +183,14 @@
       <div id="txt_229" style="position:absolute;left:677px;top:611px;width:204px;height:32px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-1">Vol XL Issue 4</span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L4']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/page39.html
+++ b/page39.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -101,44 +102,26 @@
       .P-4 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-5 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:900px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:900px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:425px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -196,112 +179,14 @@
         <p class="DefaultParagraph P-4"><span class="C-1">Volume 10, No 4</span></p>
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L5']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/page40.html
+++ b/page40.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -106,44 +107,26 @@
       .P-9 { text-align:center;margin-right:22.3px;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-5 { line-height:34.50px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1700px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1700px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:22px;top:277px;width:978px;height:1239px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -163,7 +146,7 @@
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><span class="C-4">&nbsp;</span></p>
+        <p class="Normal P-3"><span class="C-4"> </span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="DefaultParagraph P-4"><span class="C-1"><br></span></p>
       </div>
@@ -197,115 +180,17 @@
         <p class="Normal2 P-8"><span class="C-3">Many fungi collected in Newfoundland and Labrador have been covered in articles written for Omphalina, the newsletter of Foray Newfoundland and Labrador. The content of back issues of Omphalina are indexed by authors, topic , fungi species and a running tally in a Microsoft Excel spreadsheet. that can be downloaded via the link below.</span></p>
         <p class="Normal2 P-8"><span class="C-3"><br></span></p>
         <p class="Normal2 P-7"><span class="C-3"><br></span></p>
-        <p class="Normal2 P-9"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-5">Spreadhseet of Indicies of topocs, &nbsp;authors and species covered in Omphalina</a></p>
+        <p class="Normal2 P-9"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-5">Spreadhseet of Indicies of topocs,  authors and species covered in Omphalina</a></p>
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="omphalina%20v6%202016.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L3']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -107,53 +108,35 @@
       .P-9 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-7 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1600px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1600px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_174" style="position:absolute;left:32px;top:278px;width:958px;height:1149px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="Normal P-2"><span class="C-2">Links:</span></p>
         <p class="Normal P-3"><span class="C-3"><br></span></p>
-        <p class="Normal P-4"><span class="C-4">Many sites on the Web list complete or near-<wbr>complete mycological links. We do not aim to duplicate such efforts, and our incomplete list may seem somewhat arbitrary.</span></p>
+        <p class="Normal P-4"><span class="C-4">Many sites on the Web list complete or near-<wbr>complete mycological links. We do not aim to duplicate such efforts, and our incomplete list may seem somewhat arbitrary.</wbr></span></p>
         <p class="Normal P-4"><span class="C-4"><br></span></p>
-        <p class="Normal P-5"><span class="C-5">Photo-<wbr>sharing Web Sites</span></p>
-        <p class="Normal P-4"><span class="C-4">At present, the links include Facebook Groups and Flickr photo-<wbr>sharing Groups with a mycological theme. Some Individual Flickr sites devoted to fungi are also included.</span></p>
+        <p class="Normal P-5"><span class="C-5">Photo-<wbr>sharing Web Sites</wbr></span></p>
+        <p class="Normal P-4"><span class="C-4">At present, the links include Facebook Groups and Flickr photo-<wbr>sharing Groups with a mycological theme. Some Individual Flickr sites devoted to fungi are also included.</wbr></span></p>
         <p class="Normal P-4"><span class="C-4"><br></span></p>
         <p class="Normal P-5"><span class="C-5">Other Websites</span></p>
         <p class="Normal P-4"><span class="C-4">There are many Websites on mycology on the Internet. Some are maintained by professional mycologists as part of their research. Others contain encyclopedic type information on a wide range of mycology topics. Many are useful to members who wish to expand their knowledge of mushrooms biology, ecology and identification.</span></p>
@@ -166,7 +149,7 @@
         <p class="Normal P-4"><span class="C-4"><br></span></p>
         <p class="Normal P-5"><span class="C-5">Osprey</span></p>
         <p class="Normal P-4"><span class="C-4">Osprey is the magazine of Nature Newfoundland and Labrador (formerly the Newfoundland and Labrador Natural History Society).</span></p>
-        <p class="Normal P-4"><span class="C-4">It has been published by the society for over 3 decades; it provides a forum for discussion of environmental issues and is a source of information and original research material focusing on various aspects of the province’s natural history such as birds, plants, mushrooms &nbsp;insects, mammals, general ecology and philosophical nature musings. Myco-<wbr>related articles are linked here.</span></p>
+        <p class="Normal P-4"><span class="C-4">It has been published by the society for over 3 decades; it provides a forum for discussion of environmental issues and is a source of information and original research material focusing on various aspects of the province’s natural history such as birds, plants, mushrooms  insects, mammals, general ecology and philosophical nature musings. Myco-<wbr>related articles are linked here.</wbr></span></p>
         <p class="Normal P-4"><span class="C-4"><br></span></p>
         <p class="Normal P-5"><span class="C-5">Mycophile</span></p>
         <p class="Normal P-4"><span class="C-4">The Mycophile is published bimonthly by the North American Mycological Association (NAMA), with articles of interest to NAMA members, including nationwide forays and announcements, photography contest winners and award recipients, and news about the NAMA annual foray.</span></p>
@@ -181,111 +164,14 @@
         <p class="Normal P-9"><span class="C-7">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_92" style="position:absolute;left:36px;top:1484px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/science.html
+++ b/science.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -137,67 +138,49 @@
       .P-36 { margin-left:105.7px;text-indent:-1.3px;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:normal;color:#221e1f;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .OBJ-8 { background:#ffa50c; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:3000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:3000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_221" style="position:absolute;left:31px;top:298px;width:955px;height:2458px;overflow:hidden;">
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
-        <p class="DefaultParagraph P-1"><span class="C-1">One of the pleasures of a Foray is meeting like-<wbr>minded people to share in the collection, identification and cataloguing of the mycota of Newfoundland Labrador. This pleasurable task sometimes leads to academic research on fungi using on our collection stored in the herbarium at the Grenfell Campus of Memorial University. Some of this research also involves members of Foray NL. This work enables Foray NL to attract national and international academics to be part of our annual Foray &nbsp;and to collaborate in investigative projects that often result in scholarly articles like the ones listed below. </span></p>
+        <p class="DefaultParagraph P-1"><span class="C-1">One of the pleasures of a Foray is meeting like-<wbr>minded people to share in the collection, identification and cataloguing of the mycota of Newfoundland Labrador. This pleasurable task sometimes leads to academic research on fungi using on our collection stored in the herbarium at the Grenfell Campus of Memorial University. Some of this research also involves members of Foray NL. This work enables Foray NL to attract national and international academics to be part of our annual Foray  and to collaborate in investigative projects that often result in scholarly articles like the ones listed below. </wbr></span></p>
         <p class="DefaultParagraph P-1"><span class="C-1"><br></span></p>
         <p class="DefaultParagraph P-1"><span class="C-1">To access an article, click anywhere on the underlined text and a pdf file will download in a separate window.</span></p>
         <p class="Normal P-1"><span class="C-1"><br></span></p>
-        <p class="Normal P-2"><span class="C-1">2010 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2010%20Northern%20species%20of%20earth%20tongue%20genus%20Thuemenidium%20revisited.pdf" target="_blank" class="C-2">Ohenoja, Wang, Townsend, Mitchel, &nbsp;Voitk. &nbsp;</a></span></p>
+        <p class="Normal P-2"><span class="C-1">2010      <a href="science/2010%20Northern%20species%20of%20earth%20tongue%20genus%20Thuemenidium%20revisited.pdf" target="_blank" class="C-2">Ohenoja, Wang, Townsend, Mitchel,  Voitk.  </a></span></p>
         <p class="Normal P-3"><a href="science/2010%20Northern%20species%20of%20earth%20tongue%20genus%20Thuemenidium%20revisited.pdf" target="_blank" class="C-2">Northern species of earth tongue genus Thuemenidium revisited, considering morphology, ecology and molecular phylogeny. Mycologia Sept/Oct, 2010.</a></p>
         <p class="Normal P-4"><span class="C-1"><br></span></p>
-        <p class="Normal P-5"><span class="C-1">2014 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2014%20A%20revision%20of%20the%20Alpova%20diplophloeus%20complex%20in%20North%20America.pdf" target="_blank" class="C-2">Tourtelot &amp; Horton. </a></span></p>
-        <p class="Normal P-6"><a href="science/2014%20A%20revision%20of%20the%20Alpova%20diplophloeus%20complex%20in%20North%20America.pdf" target="_blank" class="C-2">A revision of the Alpova diplophloeus complex in North America. <span class="C-3">Mycologia. &nbsp;June, 2014</span></a><span class="C-4">.</span></p>
+        <p class="Normal P-5"><span class="C-1">2014      <a href="science/2014%20A%20revision%20of%20the%20Alpova%20diplophloeus%20complex%20in%20North%20America.pdf" target="_blank" class="C-2">Tourtelot &amp; Horton. </a></span></p>
+        <p class="Normal P-6"><a href="science/2014%20A%20revision%20of%20the%20Alpova%20diplophloeus%20complex%20in%20North%20America.pdf" target="_blank" class="C-2">A revision of the Alpova diplophloeus complex in North America. <span class="C-3">Mycologia.  June, 2014</span></a><span class="C-4">.</span></p>
         <p class="Normal P-1"><span class="C-1"><br></span></p>
-        <p class="Normal P-7"><span class="C-1">2015 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2015%20Hygrocybe%20jackmanii.pdf" target="_blank" class="C-2">Lebeuf, Thorn, Boertm &amp; Voitk. </a></span></p>
-        <p class="Normal P-8"><a href="science/2015%20Hygrocybe%20jackmanii.pdf" target="_blank" class="C-2">Hygrocybe jackmanii. &nbsp;Fungal Planet, December 2015.</a></p>
+        <p class="Normal P-7"><span class="C-1">2015      <a href="science/2015%20Hygrocybe%20jackmanii.pdf" target="_blank" class="C-2">Lebeuf, Thorn, Boertm &amp; Voitk. </a></span></p>
+        <p class="Normal P-8"><a href="science/2015%20Hygrocybe%20jackmanii.pdf" target="_blank" class="C-2">Hygrocybe jackmanii.  Fungal Planet, December 2015.</a></p>
         <p class="Normal P-7"><a href="science/2015%20Hygrocybe%20jackmanii.pdf" target="_blank" class="C-2"><br></a></p>
         <p class="Normal P-9"><a href="science/2015%20Type%20studies%20of%20two%20Tricholomopsis%20species%20described%20by%20Peck.pdf" target="_blank" class="C-2">Saar, Irja &amp; Voitk, </a></p>
         <p class="Normal P-9"><a href="science/2015%20Type%20studies%20of%20two%20Tricholomopsis%20species%20described%20by%20Peck.pdf" target="_blank" class="C-2">Type studies of two Tricholomopsis species described by Peck. Mycol Progress June, 2015.</a></p>
         <p class="Normal P-9"><span class="C-1"><br></span></p>
-        <p class="Normal P-10"><span class="C-1">2016 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2016%20Two%20new%20species%20of%20true%20morels%20from%20Newfoundland%20and%20Labrador.pdf" target="_blank" class="C-2">Voitk, Beug, O’Donnell &amp; Burzynski</a></span></p>
+        <p class="Normal P-10"><span class="C-1">2016      <a href="science/2016%20Two%20new%20species%20of%20true%20morels%20from%20Newfoundland%20and%20Labrador.pdf" target="_blank" class="C-2">Voitk, Beug, O’Donnell &amp; Burzynski</a></span></p>
         <p class="Normal P-3"><a href="science/2016%20Two%20new%20species%20of%20true%20morels%20from%20Newfoundland%20and%20Labrador.pdf" target="_blank" class="C-2">Two new species of true morels from Newfoundland and Labrador: cosmopolitan Morchella eohespera and parochial M. Laurentiana. Mycologia, Oct. 2015.</a></p>
         <p class="Normal P-1"><span class="C-1"><br></span></p>
-        <p class="Normal P-11"><span class="C-5">2017 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2017%20A%20hidden%20basidiolichen%20rediscovered%20Omphalina%20oreades%20is%20a.pdf" target="_blank" class="C-6">Lucking, Thorn, Saar, Piercey-<wbr>Normore, Moncada, Doering, Mann, LeBeuf, Voitk &amp; Voitk. </a></span></p>
+        <p class="Normal P-11"><span class="C-5">2017       <a href="science/2017%20A%20hidden%20basidiolichen%20rediscovered%20Omphalina%20oreades%20is%20a.pdf" target="_blank" class="C-6">Lucking, Thorn, Saar, Piercey-<wbr>Normore, Moncada, Doering, Mann, LeBeuf, Voitk &amp; Voitk. </wbr></a></span></p>
         <p class="Normal P-12"><a href="science/2017%20A%20hidden%20basidiolichen%20rediscovered%20Omphalina%20oreades%20is%20a.pdf" target="_blank" class="C-3">A hidden basidiolichen rediscovered: Omphalina oreades is a separate species in the genus Lichenomphalia (Basidiomycota: Agaricales: Hygrophoraceae). The Lichenologist, 2017.</a></p>
         <p class="Normal P-13"><span class="C-4"><br></span></p>
         <p class="Normal P-14"><a href="science/2017%20North%20American%20matsutake%20names%20clarified%20and%20a.pdf" target="_blank" class="C-3">Thorn, Kim, Lebeuf, and Voitk .</a></p>
@@ -206,147 +189,50 @@
         <p class="Normal2 P-16"><a href="science/2017-2%20Lactarius%20splendens.pdf" target="_blank" class="C-3">Jorinde Nuytinck, Annemieke Verbeken, Irja Saar, Herman Lambert, Jean Bérubé, and Andrus Voitk</a></p>
         <p class="Normal P-17"><a href="science/2017-2%20Lactarius%20splendens.pdf" target="_blank" class="C-7">Lactarius splendens<span class="C-3">, a second species with white latex in </span>Lactarius <span class="C-3">section </span>Deliciosi <span class="C-3">Botany <span class="C-8">95</span>: 859–863, April 228, 017</span></a></p>
         <p class="Normal P-18"><span class="C-5"><br></span></p>
-        <p class="Normal P-19"><a href="science/2017-4%20matsutake.pdf" target="_blank" class="C-3">Steven A. Trudell, Jianping Xu, Irja Saar, Alfredo Justo &amp; Joaquin Cifuentes. &nbsp;</a></p>
-        <p class="Normal P-19"><a href="science/2017-4%20matsutake.pdf" target="_blank" class="C-3">North American matsutake: names clarified and a new species described. Mycologia, 109:3, 379-<wbr>390, 2017.</a></p>
+        <p class="Normal P-19"><a href="science/2017-4%20matsutake.pdf" target="_blank" class="C-3">Steven A. Trudell, Jianping Xu, Irja Saar, Alfredo Justo &amp; Joaquin Cifuentes.  </a></p>
+        <p class="Normal P-19"><a href="science/2017-4%20matsutake.pdf" target="_blank" class="C-3">North American matsutake: names clarified and a new species described. Mycologia, 109:3, 379-<wbr>390, 2017.</wbr></a></p>
         <p class="Normal P-18"><a href="science/2017-4%20matsutake.pdf" target="_blank" class="C-6"><br></a></p>
         <p class="Normal P-18"><span class="C-5"><br></span></p>
-        <p class="Normal P-18"><span class="C-5">2018 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2018%20Identifying%20and%20naming%20the%20currently%20known.pdf" target="_blank" class="C-6"> <span class="C-3">Niskanen, et al. &nbsp;</span></a></span></p>
+        <p class="Normal P-18"><span class="C-5">2018      <a href="science/2018%20Identifying%20and%20naming%20the%20currently%20known.pdf" target="_blank" class="C-6"> <span class="C-3">Niskanen, et al.  </span></a></span></p>
         <p class="Normal P-20"><a href="science/2018%20Identifying%20and%20naming%20the%20currently%20known.pdf" target="_blank" class="C-3">Identifying and naming the currently known diversity of the genus <span class="C-7">Hydnum</span>, with an emphasis on European and North American taxa. Mycologia, Sept. 2018.</a></p>
         <p class="Normal P-18"><a href="science/2018%20Identifying%20and%20naming%20the%20currently%20known.pdf" target="_blank" class="C-6"><br></a></p>
         <p class="Normal P-18"><span class="C-5"><br></span></p>
         <p class="Normal P-19"><a href="science/2018%20Polyozellus%20multiplex%20(Thelephorales)%20is%20a%20species%20complex%20containing%20four%20new.pdf" target="_blank" class="C-3">Voitk, Saar, Trudell, Spirin, Beug, Kõljalg.</a></p>
-        <p class="Normal P-19"><a href="science/2018%20Polyozellus%20multiplex%20(Thelephorales)%20is%20a%20species%20complex%20containing%20four%20new.pdf" target="_blank" class="C-3">&nbsp;<span class="C-6">Polyozellus multiplex (Thelephorales) is a species complex containing four new</span></a></p>
-        <p class="Normal P-21"><a href="science/2018%20Polyozellus%20multiplex%20(Thelephorales)%20is%20a%20species%20complex%20containing%20four%20new.pdf" target="_blank" class="C-6">&nbsp;Species. Nov/Dec, 2017.</a></p>
+        <p class="Normal P-19"><a href="science/2018%20Polyozellus%20multiplex%20(Thelephorales)%20is%20a%20species%20complex%20containing%20four%20new.pdf" target="_blank" class="C-3"> <span class="C-6">Polyozellus multiplex (Thelephorales) is a species complex containing four new</span></a></p>
+        <p class="Normal P-21"><a href="science/2018%20Polyozellus%20multiplex%20(Thelephorales)%20is%20a%20species%20complex%20containing%20four%20new.pdf" target="_blank" class="C-6"> Species. Nov/Dec, 2017.</a></p>
         <p class="Normal P-21"><span class="C-5"><br></span></p>
         <p class="Normal P-22"><a href="science/2018%20The%20Inocybe%20geophylla%20group%20in%20North%20America%20A%20revision%20of%20the%20lilac%20species.pdf" target="_blank" class="C-3">Matheny &amp; Swenie. </a></p>
         <p class="Normal P-22"><a href="science/2018%20The%20Inocybe%20geophylla%20group%20in%20North%20America%20A%20revision%20of%20the%20lilac%20species.pdf" target="_blank" class="C-3">T<span class="C-6">he Inocybe geophylla group in North America A revision of the lilac species. Micologica, Nov/Dec. 2018.</span></a></p>
         <p class="Normal P-21"><span class="C-5"><br></span></p>
-        <p class="Normal P-23"><span class="C-5">2019 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><a href="science/2019%20Fomitopsis%20mounceae%20and%20F.%20schrenkii—two%20new.pdf" target="_blank" class="C-9">Haight, Nakasone, &nbsp;Laursen, &nbsp;Redhead, Taylor &amp; &nbsp;Glaeser. </a></p>
-        <p class="Normal P-24"><a href="science/2019%20Fomitopsis%20mounceae%20and%20F.%20schrenkii—two%20new.pdf" target="_blank" class="C-7">Fomitopsis mounceae <span class="C-3">and </span>F. schrenkii<span class="C-3">—two new species from North America in the </span>F. Pinicola <span class="C-3">complex. Micologia, Mar. 2019.</span></a></p>
+        <p class="Normal P-23"><span class="C-5">2019      </span><a href="science/2019%20Fomitopsis%20mounceae%20and%20F.%20schrenkii%E2%80%94two%20new.pdf" target="_blank" class="C-9">Haight, Nakasone,  Laursen,  Redhead, Taylor &amp;  Glaeser. </a></p>
+        <p class="Normal P-24"><a href="science/2019%20Fomitopsis%20mounceae%20and%20F.%20schrenkii%E2%80%94two%20new.pdf" target="_blank" class="C-7">Fomitopsis mounceae <span class="C-3">and </span>F. schrenkii<span class="C-3">—two new species from North America in the </span>F. Pinicola <span class="C-3">complex. Micologia, Mar. 2019.</span></a></p>
         <p class="Normal P-21"><span class="C-5"><br></span></p>
-        <p class="Normal P-25"><span class="C-5">2020 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="science/2020%20New%20species%20and%20reports%20of%20Cuphophyllus%20from.pdf" target="_blank" class="C-3">Voitk, &nbsp;Saar, Lodge, Boertmann, Berch, Larsson</a></span></p>
-        <p class="Normal P-26"><a href="science/2020%20New%20species%20and%20reports%20of%20Cuphophyllus%20from.pdf" target="_blank" class="C-3">New species and reports of <span class="C-7">Cuphophyllus </span>from northern North America compared with related &nbsp;Eurasian species. Mycologica, Feb. 2020</a></p>
+        <p class="Normal P-25"><span class="C-5">2020       <a href="science/2020%20New%20species%20and%20reports%20of%20Cuphophyllus%20from.pdf" target="_blank" class="C-3">Voitk,  Saar, Lodge, Boertmann, Berch, Larsson</a></span></p>
+        <p class="Normal P-26"><a href="science/2020%20New%20species%20and%20reports%20of%20Cuphophyllus%20from.pdf" target="_blank" class="C-3">New species and reports of <span class="C-7">Cuphophyllus </span>from northern North America compared with related  Eurasian species. Mycologica, Feb. 2020</a></p>
         <p class="Normal P-27"><span class="C-5"><br></span></p>
         <p class="Normal P-28"><a href="science/2020%20The%20Pseudoomphalina%20kalchbrenneri%20complex%20in%20North%20America.pdf" target="_blank" class="C-3">Voitk,Saar, Lebeuf, and Kennedy. </a></p>
         <p class="Normal P-29"><a href="science/2020%20The%20Pseudoomphalina%20kalchbrenneri%20complex%20in%20North%20America.pdf" target="_blank" class="C-6">The Pseudoomphalina kalchbrenneri complex in North America. Botany, Jan. 2020.</a></p>
-        <p class="Normal P-30"><span class="C-5">&nbsp;</span></p>
+        <p class="Normal P-30"><span class="C-5"> </span></p>
         <p class="Normal P-31"><a href="science/2020-2%20Cupho.pdf" target="_blank" class="C-3">Andrus Voitk, Irja Saar, D. Jean Lodge, David Boertmann, Shannon M. Berch &amp; Ellen Larsson </a></p>
         <p class="Normal P-31"><a href="science/2020-2%20Cupho.pdf" target="_blank" class="C-3">New species and reports of <span class="C-7">Cuphophyllus </span>from northern North America compared with related Eurasian species. Mycologia, Feb. 2020.</a></p>
         <p class="Normal P-31"><a href="science/2020-2%20Cupho.pdf" target="_blank" class="C-2"><br></a></p>
-        <p class="Normal2 P-32"><a href="science/2020-4.pdf" target="_blank" class="C-3">R. Greg Thorn, David W. Malloch, Irja Saar, Yves Lamoureux, Eiji Nagasawa, Scott A. Redhead, Simona Margaritescu, and Jean-<wbr>Marc Moncalvo. </a></p>
+        <p class="Normal2 P-32"><a href="science/2020-4.pdf" target="_blank" class="C-3">R. Greg Thorn, David W. Malloch, Irja Saar, Yves Lamoureux, Eiji Nagasawa, Scott A. Redhead, Simona Margaritescu, and Jean-<wbr>Marc Moncalvo. </wbr></a></p>
         <p class="Normal2 P-32"><a href="science/2020-4.pdf" target="_blank" class="C-3">New species in the <span class="C-7">Gymnopilus junonius </span>group (Basidiomycota: Agaricales) Botany <span class="C-8">98</span>: 293–315, 2020.</a></p>
         <p class="Normal2 P-32"><a href="science/2020-4.pdf" target="_blank" class="C-2"><br></a></p>
-        <p class="Normal2 P-33"><a href="science/2020-3_Catathelasma_Vizzini.pdf" target="_blank" class="C-3">Alfredo Vizzini, Giovanni Consiglio, &nbsp;Mauro Marchetti, Pablo Alvarado. </a></p>
+        <p class="Normal2 P-33"><a href="science/2020-3_Catathelasma_Vizzini.pdf" target="_blank" class="C-3">Alfredo Vizzini, Giovanni Consiglio,  Mauro Marchetti, Pablo Alvarado. </a></p>
         <p class="Normal2 P-33"><a href="science/2020-3_Catathelasma_Vizzini.pdf" target="_blank" class="C-3">Insights into the <span class="C-7">Tricholomatineae </span>(<span class="C-7">Agaricales</span>, <span class="C-7">Agaricomycetes</span>):a new arrangement of <span class="C-7">Biannulariaceae </span>and <span class="C-7">Callistosporium</span>, <span class="C-7">Callistosporiaceae </span>fam. nov., <span class="C-7">Xerophorus </span>stat. nov., and <span class="C-7">Pleurocollybia </span>incorporated into <span class="C-7">Callistosporium </span></a></p>
         <p class="Default P-34"><span class="C-10"><br></span></p>
-        <p class="Default P-35"><span class="C-10">&nbsp;</span><a href="science/2020%20T12-Voitk-2900.pdf" target="_blank" class="C-11">Andrus Voitk, Irja Saar, Robert Lücking, Pierre-<wbr>Arthur Moreau, Gilles Corriol, Irmgard Krisai-<wbr>Greilhuber, R. Greg Thorn, Chris R. J. Hay, Bibiana Moncada &amp; Gro Gulden.</a></p>
+        <p class="Default P-35"><span class="C-10"> </span><a href="science/2020%20T12-Voitk-2900.pdf" target="_blank" class="C-11">Andrus Voitk, Irja Saar, Robert Lücking, Pierre-<wbr>Arthur Moreau, Gilles Corriol, Irmgard Krisai-<wbr>Greilhuber, R. Greg Thorn, Chris R. J. Hay, Bibiana Moncada &amp; Gro Gulden.</wbr></wbr></a></p>
         <p class="Default P-36"><a href="science/2020%20T12-Voitk-2900.pdf" target="_blank" class="C-11">Surprising morphological, ecological and ITS sequence diversity in the Arrhenia acerosa complex (Basidiomy­cota: Agaricales: Hygrophoraceae) </a></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/search.html
+++ b/search.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -114,44 +115,26 @@
       .P-11 { text-align:center;line-height:1px;font-family:"Times New Roman", serif;font-style:normal;font-weight:normal;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .P-12 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1200px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1200px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_47" style="position:absolute;left:24px;top:262px;width:978px;height:762px;overflow:hidden;">
         <p class="Normal"><span class="C-1"><br></span></p>
@@ -171,13 +154,13 @@
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal2 P-1"><span class="C-2"><br></span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
-        <p class="Normal P-3"><span class="C-4">&nbsp;</span></p>
+        <p class="Normal P-3"><span class="C-4"> </span></p>
         <p class="Normal P-2"><span class="C-3"><br></span></p>
         <p class="Normal P-4"><span class="C-5">Omphalina Indicies</span></p>
         <p class="Normal P-5"><span class="C-3"><br></span></p>
         <p class="Normal P-6"><span class="C-3">Many fungi collected in Newfoundland and Labrador have been covered in articles written for Omphalina, the newsletter of Foray Newfoundland and Labrador. The content of back issues of Omphalina are indexed by authors, topic , fungi species and a running tally in a Microsoft Excel spreadsheet. that can be downloaded via the link below.</span></p>
         <p class="Normal P-7"><span class="C-3"><br></span></p>
-        <p class="Normal P-8"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-6">Spreadhseet of Indicies of topocs, &nbsp;authors and species covered in Omphalina</a></p>
+        <p class="Normal P-8"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-6">Spreadhseet of Indicies of topocs,  authors and species covered in Omphalina</a></p>
       </div>
       <div id="txt_172" style="position:absolute;left:62px;top:297px;width:359px;height:383px;overflow:hidden;">
         <p class="Normal2 P-1"><span class="C-2">Search Back Issues of Omphalina</span></p>
@@ -187,7 +170,7 @@
         <p class="Normal"><span class="C-8">The search engine belong to Memorial University of Newfoundland’s Digital Archives Initiative.</span></p>
         <p class="Normal"><span class="C-8"><br></span></p>
         <p class="Normal"><span class="C-9"><br></span></p>
-        <p class="Normal P-10"><a href="https://collections.mun.ca/digital/collection/omphalina/search/" target="_blank" class="C-10">Search &nbsp;Archives Now</a></p>
+        <p class="Normal P-10"><a href="https://collections.mun.ca/digital/collection/omphalina/search/" target="_blank" class="C-10">Search  Archives Now</a></p>
       </div>
       <div id="txt_164" style="position:absolute;left:45px;top:1075px;width:951px;height:84px;overflow:hidden;">
         <p class="DefaultParagraph P-11"><span class="C-1"><br></span></p>
@@ -195,112 +178,14 @@
         <p class="Normal P-12"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_94" style="position:absolute;left:45px;top:1073px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L1']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/spec/navigation_spec.rb
+++ b/spec/navigation_spec.rb
@@ -2,21 +2,23 @@ require "spec_helper"
 
 RSpec.describe "Site navigation", type: :feature do
   NAV_LINKS = {
-    nav_4_B1: "index.html",
-    nav_4_B2: "foray_2025.html",
-    nav_4_B3: "foray_reports.html",
-    nav_4_B4: "species_list_explanations.html",
-    nav_4_B5: "omphalina.html",
-    nav_4_B6: "science.html",
-    nav_4_B7: "resources.html",
-    nav_4_B8: "about_us.html",
-    nav_4_B9: "membership.html"
+    "Home" => "index.html",
+    "Foray 2025" => "foray_2025.html",
+    "Foray Reports" => "foray_reports.html",
+    "Species List Explanations" => "species_list_explanations.html",
+    "Omphalina" => "omphalina.html",
+    "Science" => "science.html",
+    "Resources" => "resources.html",
+    "About Us" => "about_us.html",
+    "Membership" => "membership.html"
   }.freeze
 
-  NAV_LINKS.each do |id, path|
+  NAV_LINKS.each do |text, path|
     it "navigates to #{path} and finds heading and content" do
       visit "/index.html"
-      find("##{id}").click
+      within("#main-nav") do
+        click_link text
+      end
       expect(page).to have_current_path("/#{path}")
       expect(page.title).not_to be_empty
       expect(page).to have_css("p", minimum: 1)

--- a/species_list_by_foray.html
+++ b/species_list_by_foray.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -101,44 +102,26 @@
       .P-4 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:16.0px;vertical-align:0; }
       .C-5 { line-height:20.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:16.0px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:3000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:3000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_126" style="position:absolute;left:44px;top:296px;width:948px;height:182px;overflow:hidden;">
         <p class="DefaultParagraph"><span class="C-1"><br></span></p>
@@ -284,7 +267,7 @@
         <p class="Normal P-4"><span class="C-5">2015</span></p>
       </div>
       <div id="txt_204" style="position:absolute;left:71px;top:2446px;width:208px;height:46px;overflow:hidden;">
-        <p class="DefaultParagraph P-4"><span class="C-5">Happy Valley-<wbr>Goose Bay</span></p>
+        <p class="DefaultParagraph P-4"><span class="C-5">Happy Valley-<wbr>Goose Bay</wbr></span></p>
         <p class="Normal P-4"><span class="C-5">2016</span></p>
       </div>
       <a href="species_lists/Gros%20Morne%202014.pdf" target="_blank">
@@ -302,114 +285,16 @@
       </a>
       <div id="txt_233" style="position:absolute;left:71px;top:779px;width:198px;height:46px;overflow:hidden;">
         <p class="DefaultParagraph P-4"><span class="C-5">Cumulative Index</span></p>
-        <p class="Normal P-4"><span class="C-5">2003-<wbr>2016</span></p>
+        <p class="Normal P-4"><span class="C-5">2003-<wbr>2016</wbr></span></p>
       </div>
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B4M_L2']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/species_list_explanations.html
+++ b/species_list_explanations.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -111,48 +112,30 @@
       .P-7 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-8 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1300px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1300px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton Down" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_11" style="position:absolute;left:37px;top:272px;width:942px;height:887px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
-        <p class="Normal2 P-2">The exact number of mushroom species growing in the province of Newfoundland and Labrador is unknown. Estimates have been placed at around 8000, somewhat short of the ten thousand believed to be growing on adjacent continental North America. Foray NL believes that species considered typical in this province are around 1200 -<wbr> 1500 and that most have been located. It is likely that with time and increased canvassing of the province, more species will be discovered. </p>
+        <p class="Normal2 P-2">The exact number of mushroom species growing in the province of Newfoundland and Labrador is unknown. Estimates have been placed at around 8000, somewhat short of the ten thousand believed to be growing on adjacent continental North America. Foray NL believes that species considered typical in this province are around 1200 -<wbr> 1500 and that most have been located. It is likely that with time and increased canvassing of the province, more species will be discovered. </wbr></p>
         <p class="Normal2 P-2"><br></p>
         <p class="Normal P-2">The three webpages displayed in the pull down menu in this navigation bar tab lists most of the mushroom species collected, identified and photographed by Foray NL over the years. The lists are primarily Friesian (classified by morphology), with a very modest nod to phylogenic relationships. All items are arranged alphabetically.</p>
         <p class="Normal P-2"><br></p>
@@ -162,7 +145,7 @@
         <p class="Normal2 P-2"><br></p>
         <p class="Normal2 P-4">2. List by Foray<span class="C-5">: lists species collected at each Foray. The lists are presented by year with the general Foray location indicated for each one. They are presented as PDF files. You can refer to them when visiting an area previously covered by a Foray to get an indication of what mushrooms you can expect or hope to find in the area, although not all species will be found on all trails covered during the Foray. </span></p>
         <p class="Normal2 P-2"><br></p>
-        <p class="Normal2 P-4">3. Flickr Images<span class="C-5">: displays the cumulative index via the Flickr photo-<wbr>sharing website. The links on this page match the table of contents of the printable cumulative index above. This will make it easier for you to find the mushrooms images you want. </span></p>
+        <p class="Normal2 P-4">3. Flickr Images<span class="C-5">: displays the cumulative index via the Flickr photo-<wbr>sharing website. The links on this page match the table of contents of the printable cumulative index above. This will make it easier for you to find the mushrooms images you want. </wbr></span></p>
         <p class="Normal P-2"><br></p>
         <p class="Normal P-4">4. Phyla/Genera<span class="C-5">: displays an index of voucher images as organized by phyla and also by genera. The former will narrow the display of species images to phyla. The latter will display alphabetically all of the genera located by Foray NL. These list can be used to visually compare your finds to species collected by Foray NL. Depending on the species, the collection of images sometimes show different stages in a mushroom’s development and the variations that can be seen between individuals in the same species. Because of the time between collection and photographing, some species will show some differences with ones seen in situ.</span></p>
         <p class="Normal P-5"><span class="C-6"><br></span></p>
@@ -174,111 +157,14 @@
         <p class="Normal P-7"><span class="C-8">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_90" style="position:absolute;left:36px;top:1183px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/species_lists.html
+++ b/species_lists.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -126,44 +127,26 @@
       .P-14 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-8 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:1000px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:1000px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <div class="OBJ-8" id="txt_11" style="position:absolute;left:28px;top:273px;width:551px;height:515px;overflow:hidden;">
         <p class="Normal P-1"><span class="C-1"><br></span></p>
@@ -173,7 +156,7 @@
         <p class="Normal2 P-5"><span class="C-3"><br></span></p>
         <p class="Normal2 P-6"><span class="C-3">Many fungi collected in Newfoundland and Labrador have been covered in articles written for Omphalina, the newsletter of Foray Newfoundland and Labrador. The content of back issues of Omphalina are indexed by authors, topic , fungi species and a running tally in a Microsoft Excel spreadsheet. that can be downloaded via the link below.</span></p>
         <p class="Normal2 P-6"><span class="C-3"><br></span></p>
-        <p class="Normal2 P-7"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-4">Spreadhseet of Indicies of topics, &nbsp;</a></p>
+        <p class="Normal2 P-7"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-4">Spreadhseet of Indicies of topics,  </a></p>
         <p class="Normal2 P-7"><a href="species_lists/Omphalina%20contents.xlsx" target="_blank" class="C-4">authors and species covered in Omphalina</a></p>
         <p class="Normal2 P-2"><br></p>
         <p class="Normal P-2"><br></p>
@@ -190,112 +173,14 @@
         <p class="Normal P-14"><span class="C-8">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_101" style="position:absolute;left:36px;top:871px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton Down" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B4M_L1']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/submission_guidelines.html
+++ b/submission_guidelines.html
@@ -1,6 +1,7 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JSEZXHQW0T"></script>
 <script>
@@ -93,44 +94,26 @@
       .P-2 { text-align:center;line-height:1px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;font-variant:normal;font-size:19.0px;vertical-align:0; }
       .C-2 { line-height:23.00px;font-family:"Arial", sans-serif;font-style:normal;font-weight:700;color:#000000;background-color:transparent;text-decoration:none;font-variant:normal;font-size:18.7px;vertical-align:0; }
     </style>
-    <script type="text/javascript" src="_wp_scripts/jquery.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-      $("a.ActiveButton").bind({ mousedown:function(){if ( $(this).attr('disabled') === undefined ) $(this).addClass('Activated');}, mouseleave:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}, mouseup:function(){ if ( $(this).attr('disabled') === undefined ) $(this).removeClass('Activated');}});
-      });
-    </script>
+    
+    
   </head>
   <body style="height:800px;background:#ffffff;">
+<nav id="main-nav" aria-label="Main navigation">
+  <ul class="nav-list">
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/foray_2025.html">Foray 2025</a></li>
+    <li><a href="/foray_reports.html">Foray Reports</a></li>
+    <li><a href="/species_list_explanations.html">Species List Explanations</a></li>
+    <li><a href="/omphalina.html">Omphalina</a></li>
+    <li><a href="/science.html">Science</a></li>
+    <li><a href="/resources.html">Resources</a></li>
+    <li><a href="/about_us.html">About Us</a></li>
+    <li><a href="/membership.html">Membership</a></li>
+  </ul>
+</nav>
+
     <div id="divMain" style="background:#ffffff;margin-left:auto;margin-right:auto;position:relative;width:1024px;height:800px;">
-      <div id="nav_4" class="OBJ-1" style="position:absolute;left:-25px;top:206px;width:1077px;height:63px;">
-        <a href="index.html" id="nav_4_B1" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:39px;top:5px;width:102px;height:39px;">
-          <span>Home</span>
-        </a>
-        <a href="foray_2025.html" title="Date and location and related details of upcoming forays, Foray Newfoundland and Labrador." id="nav_4_B2" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:151px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;2025</span>
-        </a>
-        <a href="foray_reports.html" id="nav_4_B3" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:263px;top:5px;width:102px;height:39px;">
-          <span>Foray&nbsp;Reports</span>
-        </a>
-        <a href="species_list_explanations.html" id="nav_4_B4" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:375px;top:5px;width:102px;height:39px;">
-          <span>Species&nbsp;List</span>
-        </a>
-        <a href="omphalina.html" id="nav_4_B5" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:487px;top:5px;width:102px;height:39px;">
-          <span>Omphalina</span>
-        </a>
-        <a href="science.html" id="nav_4_B6" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:599px;top:5px;width:102px;height:39px;">
-          <span>Science</span>
-        </a>
-        <a href="resources.html" id="nav_4_B7" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:711px;top:5px;width:102px;height:39px;">
-          <span>Resources</span>
-        </a>
-        <a href="about_us.html" id="nav_4_B8" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:823px;top:5px;width:102px;height:39px;">
-          <span>About&nbsp;Us</span>
-        </a>
-        <a href="membership.html" title="Lists the benefits of membership and provides downloadable membershop firm." id="nav_4_B9" class="OBJ-2 ActiveButton" style="display:block;position:absolute;left:935px;top:5px;width:102px;height:39px;">
-          <span>Membership</span>
-        </a>
-      </div>
+      
       <img alt="" src="_wp_generated/wp1da48039_05_06.jpg" id="pic_62" style="position:absolute;left:23px;top:27px;width:978px;height:171px;">
       <map id="map1" name="map1"><area shape="rect" coords="128,158,289,178" href="omphaline/App1.pdf" target="_blank" alt=""></map>
       <img alt="" usemap="#map1" src="_wp_generated/wpce7caff1_06.png" id="txt_109" style="position:absolute;left:259px;top:283px;width:700px;height:263px;">
@@ -141,112 +124,14 @@
         <p class="Normal P-2"><span class="C-2">Email; &lt;webmaster@nlmushrooms.ca&gt;</span></p>
       </div>
       <img alt="" src="_wp_generated/wp293ec477_06.png" id="img_96" style="position:absolute;left:36px;top:681px;width:951px;height:3px;">
-      <div id="nav_4_B3M" style="position:absolute;visibility:hidden;width:145px;height:51px;background:transparent url('_wp_generated/wp52973598_06.png') no-repeat scroll left top;">
-        <a href="foray_reports_all.html" id="nav_4_B3M_L1" class="OBJ-3 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:105px;height:31px;">
-          <span>2003-Present</span>
-        </a>
-      </div>
-      <div id="nav_4_B4M" style="position:absolute;visibility:hidden;width:274px;height:144px;background:transparent url('_wp_generated/wpcc1f5768_06.png') no-repeat scroll left top;">
-        <a href="species_lists.html" title="An annotated list of most of the mushroom species found, catalogued and photographed by Foray NL." id="nav_4_B4M_L1" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:234px;height:31px;">
-          <span>Omphalina&nbsp;Indices</span>
-        </a>
-        <a href="species_list_by_foray.html" title="Species List by Individual Forays in Newfoundland and Labrador between 2003 and the present." id="nav_4_B4M_L2" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:234px;height:31px;">
-          <span>Cumulative&nbsp;and&nbsp;Foray&nbsp;Species&nbsp;list</span>
-        </a>
-        <a href="flickr_image_index.html" title="An index of the mushrooms groups stored on Flickr photo-sharing web site. The list follows the table of contents of the the annottated cumulative index." id="nav_4_B4M_L3" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:234px;height:31px;">
-          <span>Flickr&nbsp;Images</span>
-        </a>
-        <a href="flickr_voucher_images.html" title="Contains links to voucher Foray NL voucher images. Links include tweo collections: by Phyla and by Genera. Images are organized alphabetically." id="nav_4_B4M_L4" class="OBJ-4 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:234px;height:31px;">
-          <span>&nbsp;Phyla/Genera&nbsp;Images</span>
-        </a>
-      </div>
-      <div id="nav_4_B5M" style="position:absolute;visibility:hidden;width:203px;height:485px;background:transparent url('_wp_generated/wp1b1da644_06.png') no-repeat scroll left top;">
-        <a href="search.html" title="Search back issues of Omphalina at Memorial University&#39;s Digital Archives Initiative." id="nav_4_B5M_L1" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:163px;height:31px;">
-          <span>Search&nbsp;Back&nbsp;Issues</span>
-        </a>
-        <a href="current%20issue.html" title="Current issue of Omphalina, the newsletter of Foray Newfoundland and Labrador. Available free online." id="nav_4_B5M_L2" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:163px;height:31px;">
-          <span>&nbsp;Current&nbsp;Issue</span>
-        </a>
-        <a href="page40.html" id="nav_4_B5M_L3" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:163px;height:31px;">
-          <span>Vol&nbsp;12,&nbsp;2021</span>
-        </a>
-        <a href="page38.html" title="Contains back issues of Omphalina published in 2019." id="nav_4_B5M_L4" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:163px;height:31px;">
-          <span>Vol&nbsp;11,&nbsp;2020</span>
-        </a>
-        <a href="page39.html" id="nav_4_B5M_L5" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:163px;height:31px;">
-          <span>Vol&nbsp;10,&nbsp;2019</span>
-        </a>
-        <a href="page37.html" id="nav_4_B5M_L6" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:165px;width:163px;height:31px;">
-          <span>Vol&nbsp;9,&nbsp;2018</span>
-        </a>
-        <a href="omphalina_2017_1.html" title="Omphalina 2016 volume 7 issues 1-8. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L7" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:196px;width:163px;height:31px;">
-          <span>Vol&nbsp;8,&nbsp;2017</span>
-        </a>
-        <a href="page36.html" id="nav_4_B5M_L8" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:227px;width:163px;height:31px;">
-          <span>Vol&nbsp;7,&nbsp;2016</span>
-        </a>
-        <a href="omphalina_2015_1.html" title="Omphalina 2015 volume 6 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L9" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:258px;width:163px;height:31px;">
-          <span>Vol&nbsp;6,&nbsp;2015</span>
-        </a>
-        <a href="omphalina_2014.html" title="Omphalina 2014 volume 5 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L10" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:289px;width:163px;height:31px;">
-          <span>Vol&nbsp;5,&nbsp;2014</span>
-        </a>
-        <a href="omphalina_2013_1.html" title="Omphalina 2013 volume 4 issues 1-11. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L11" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:320px;width:163px;height:31px;">
-          <span>Vol&nbsp;4,&nbsp;2013</span>
-        </a>
-        <a href="omphalina_2012_1.html" title="Omphalina 2026 volume37 issues 1-12. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L12" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:351px;width:163px;height:31px;">
-          <span>Vol&nbsp;3,&nbsp;2012</span>
-        </a>
-        <a href="omphalina_2011_1.html" title="Omphalina 2011 volume 2 issues 1-9. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L13" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:382px;width:163px;height:31px;">
-          <span>Vol&nbsp;2,&nbsp;2011</span>
-        </a>
-        <a href="omphalina_2010_1.html" title="Omphalina 2010 volume 1 issues 1-7. Omphalina is the of Newsletter Foray Newfoundland and Labrador." id="nav_4_B5M_L14" class="OBJ-5 ActiveButton" style="display:block;position:absolute;left:20px;top:413px;width:163px;height:31px;">
-          <span>Vol&nbsp;1,&nbsp;2010</span>
-        </a>
-        <a href="submission_guidelines.html" title="Submission guidelines for visitors wishing to contribute to Omphalina." id="nav_4_B5M_L15" class="OBJ-5 ActiveButton Down" style="display:block;position:absolute;left:20px;top:444px;width:163px;height:31px;">
-          <span>Submission&nbsp;Guidelines</span>
-        </a>
-      </div>
-      <div id="nav_4_B7M" style="position:absolute;visibility:hidden;width:164px;height:175px;background:transparent url('_wp_generated/wpef41f5f8_06.png') no-repeat scroll left top;">
-        <a href="articles_fungi_magazine.html" id="nav_4_B7M_L1" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:124px;height:31px;">
-          <span>Fungi</span>
-        </a>
-        <a href="mycophyle_articles.html" title="Articles published in Mycophyle, " id="nav_4_B7M_L2" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:124px;height:31px;">
-          <span>Mycophile</span>
-        </a>
-        <a href="facebook_links.html" title="Lists links to Facebook Groups that have a mycology theme of use to Foray NL membership." id="nav_4_B7M_L3" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:124px;height:31px;">
-          <span>&nbsp;Face&nbsp;Book</span>
-        </a>
-        <a href="osprey.html" id="nav_4_B7M_L4" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:124px;height:31px;">
-          <span>Osprey</span>
-        </a>
-        <a href="fungal_websites.html" id="nav_4_B7M_L5" class="OBJ-6 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:124px;height:31px;">
-          <span>Fungal&nbsp;Websites</span>
-        </a>
-      </div>
-      <div id="nav_4_B8M" style="position:absolute;visibility:hidden;width:134px;height:175px;background:transparent url('_wp_generated/wp474f744d_06.png') no-repeat scroll left top;">
-        <a href="contacts.html" id="nav_4_B8M_L1" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:10px;width:94px;height:31px;">
-          <span>Contacts</span>
-        </a>
-        <a href="mission.html" id="nav_4_B8M_L2" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:41px;width:94px;height:31px;">
-          <span>Mission</span>
-        </a>
-        <a href="board.html" id="nav_4_B8M_L3" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:72px;width:94px;height:31px;">
-          <span>Board</span>
-        </a>
-        <a href="bylaws.html" id="nav_4_B8M_L4" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:103px;width:94px;height:31px;">
-          <span>By&nbsp;Laws</span>
-        </a>
-        <a href="consultants.html" id="nav_4_B8M_L5" class="OBJ-7 ActiveButton" style="display:block;position:absolute;left:20px;top:134px;width:94px;height:31px;">
-          <span>Consultants</span>
-        </a>
-      </div>
+      
+      
+      
+      
+      
     </div>
     <script type="text/javascript" src="_wp_scripts/jsMenu.js"></script>
-    <script type="text/javascript">
-      wpmenustack.setCurrent(['nav_4_B5M_L15']);
-      wpmenustack.setRollovers([['nav_4_B1',''],['nav_4_B2',''],['nav_4_B3','nav_4_B3M',{"m_vertical":true}],['nav_4_B4','nav_4_B4M',{"m_vertical":true}],['nav_4_B5','nav_4_B5M',{"m_vertical":true}],['nav_4_B6',''],['nav_4_B7','nav_4_B7M',{"m_vertical":true}],['nav_4_B8','nav_4_B8M',{"m_vertical":true}],['nav_4_B9','']]);
-      wpmenustack.setMenus(['nav_4_B3M','nav_4_B4M','nav_4_B5M','nav_4_B7M','nav_4_B8M'],{"m_vOffset":2,"m_vAlignment":1});
-    </script>
-  </body>
+    
+  <script src="/_wp_scripts/navigation.js"></script>
+</body>
 </html>

--- a/tools/update_nav.rb
+++ b/tools/update_nav.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require 'nokogiri'
+
+NAV_PATH = File.join(File.dirname(__dir__), 'navigation.html')
+NAV_HTML = File.read(NAV_PATH)
+
+Dir.glob(File.join(File.dirname(__dir__), '**/*.html')).each do |file|
+  next if File.basename(file) == 'navigation.html'
+  doc = Nokogiri::HTML(File.read(file))
+  # remove old nav and related dropdown menus
+  doc.css('#nav_4').remove
+  doc.css('[id^="nav_4_B"]').remove
+  # remove scripts for old menu
+  doc.xpath("//script[contains(., 'wpmenustack')]").remove
+  doc.xpath("//script[contains(., 'ActiveButton')]").remove
+  doc.at_css('script[src*="jquery.js"]')&.remove
+  # remove any existing main-nav
+  doc.css('#main-nav').remove
+  # insert new nav at top of body
+  if body = doc.at('body')
+    body.children.first.add_previous_sibling(Nokogiri::HTML::DocumentFragment.parse(NAV_HTML))
+    body.add_child('<script src="/_wp_scripts/navigation.js"></script>')
+    File.write(file, doc.to_html)
+    puts "Updated #{file}"
+  else
+    warn "No body tag in #{file}"
+  end
+end


### PR DESCRIPTION
## Summary
- replace legacy `nav_4` menu with semantic `<nav>` markup across pages
- style navigation and focus states in CSS; drop jQuery menu code
- add script to mark current page and supply new nav template and updater

## Testing
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_689a4e9f816883219fe7095a2e51aabb